### PR TITLE
生成残りカウント取得エラーの解決

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -17,6 +17,7 @@ gem "aws-sdk-s3"                 # Amazon S3/LocalStackとの連携
 # ========================
 gem "rack-cors"                  # CORS制御（Next.jsとの連携に必須）
 gem "faraday"                    # HTTPクライアント（OpenAI, Clerk等API呼び出しに）
+gem "ruby-openai", "~> 8.1.0"    # OpenAI APIクライアント
 
 # ========================
 # 🔑 認証・セキュリティ

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
+    event_stream_parser (1.0.0)
     factory_bot (6.5.2)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.4.4)
@@ -146,6 +147,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     globalid (1.2.1)
@@ -177,6 +180,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
@@ -315,6 +319,10 @@ GEM
       rubocop (>= 1.72)
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
+    ruby-openai (8.1.0)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     stringio (3.1.7)
@@ -364,6 +372,7 @@ DEPENDENCIES
   rails (~> 7.1.3)
   rspec-rails
   rubocop-rails-omakase
+  ruby-openai (~> 8.1.0)
   tzinfo-data
 
 BUNDLED WITH

--- a/backend/app/controllers/api/v1/cheers_controller.rb
+++ b/backend/app/controllers/api/v1/cheers_controller.rb
@@ -3,6 +3,9 @@ module Api
   module V1
     class CheersController < ApplicationController
       # 認証ミドルウェアはApplicationControllerでinclude済み
+      
+      #開発中は「回数取得系API」だけ認証スキップ
+      skip_before_action :authenticate_with_jwt!, only: [:generate_count, :share_bonus]
 
       # GET /api/v1/cheers
       def index
@@ -132,7 +135,17 @@ module Api
       def generate_count
         kind = params[:kind] || "text_ai"
         limit = AiGenerationLimit.for(@current_user, kind)
-        render json: { remaining: limit.remaining, max: limit.max_count, count: limit.count, bonus_count: limit.bonus_count }
+
+        # 例: can_shareの定義（1日1回までシェアボーナス）
+        can_share = (limit.bonus_count < 1)
+
+        render json: { 
+          remaining: limit.remaining, 
+          can_share: can_share,
+          max: limit.max_count, 
+          count: limit.count, 
+          bonus_count: limit.bonus_count 
+        }
       end
 
       private

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -1,3 +1,15 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
 ActiveRecord::Schema[7.1].define(version: 2025_06_01_073555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/frontend/components/cheer/GenerateCountInfo.tsx
+++ b/frontend/components/cheer/GenerateCountInfo.tsx
@@ -1,6 +1,5 @@
 // frontend/components/cheer/GenerateCountInfo.tsx
 //回数表示＆シェアボタンUIコンポーネント
-
 "use client";
 
 import { useEffect, useState } from "react";

--- a/frontend/lib/api/aiLimit.ts
+++ b/frontend/lib/api/aiLimit.ts
@@ -1,7 +1,8 @@
 // front/lib/api/aiLimit.ts
+import { getBaseUrl } from "@/lib/utils/getBaseUrl";
 
 //環境に応じたAPIベースURLを設定
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL;
+const API_BASE = getBaseUrl();
 
 //api/v1/cheers/generate_count?kind=text_ai or image_ai
 //現在の残り回数・シェア済か取得API
@@ -12,6 +13,7 @@ export async function getAiLimit(kind: "text_ai" | "image_ai") {
   if (!res.ok) throw new Error("取得に失敗しました");
   return await res.json() as { remaining: number, can_share: boolean };
 }
+
 
 //POST /api/v1/cheers/share_bonus{ kind: "text_ai" or "image_ai" }
 //シェアボーナス（+1回）を付与API

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -4,3 +4,4 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+

--- a/frontend/lib/utils/getBaseUrl.ts
+++ b/frontend/lib/utils/getBaseUrl.ts
@@ -1,0 +1,16 @@
+// lib/utils/getBaseUrl.ts
+//柔軟なAPIベースURL解決ユーティリティ
+
+export function getBaseUrl() {
+  // ブラウザの場合（== "外部から"アクセス。開発/本番両方あり得る）
+  if (typeof window !== "undefined") {
+    // まず本番URLが定義されていればそちら優先
+    if (process.env.NEXT_PUBLIC_BACKEND_PUBLIC_URL) {
+      return process.env.NEXT_PUBLIC_BACKEND_PUBLIC_URL;
+    }
+    // なければローカル（開発用APIサーバを直接叩く）
+    return "http://localhost:3000";
+  }
+  // SSRやAPI Routesなどサーバサイド（Docker Composeで動く想定）
+  return process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://backend:3000";
+}


### PR DESCRIPTION
フロント（Next.js）からAPIリクエスト先が不正
　→　NEXT_PUBLIC_BACKEND_PUBLIC_URL（ダミーURL）が優先されていた

NEXT_PUBLIC_BACKEND_URL=http://backend:3000 のみを.env.localに記載
　→　本番用URLはコメントアウト

getBaseUrlユーティリティでAPIエンドポイントを動的に決定
　→　開発時はbackend:3000が使われるように

NetworkタブでリクエストURL・レスポンスを確認し、curlでも動作検証

本番環境では本番APIのURLだけ設定すればOKと判断し、運用方針を明確化