### PR TITLE
S3とlocalstack設定

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -26,26 +26,49 @@ jobs:
         with:
           node-version: 20
 
-      # ③ 依存パッケージをインストール（npm ci: package-lock.jsonと同期）
+      # ③ 依存パッケージをインストール
       - name: Install dependencies
         run: npm ci
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
 
       # ④ Lint（ESLint）を実行
       - name: Lint
         run: npm run lint
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
 
       # ⑤ TypeScriptの型チェック
       - name: Type check
         run: npm run typecheck
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
 
       # ⑥ Next.jsのビルド
       - name: Build
         run: npm run build
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
 
-      # ⑦（後から追加できるポイント）Jestテスト導入後、下のコメントアウトを外すだけ！
+      # ⑦ テストなどは必要に応じて後から追記可能
       # - name: Run Jest tests
       #   run: npm test -- --ci
+      #   env:
+      #     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      #     CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      #     NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
 
-      # ⑧（後から追加できるポイント）E2Eテスト導入時はここに追加
       # - name: Run Playwright tests
       #   run: npx playwright test
+      #   env:
+      #     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      #     CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      #     NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}

--- a/backend/app/controllers/api/v1/uploads_controller.rb
+++ b/backend/app/controllers/api/v1/uploads_controller.rb
@@ -1,0 +1,79 @@
+# backend/app/controllers/api/v1/uploads_controller.rb
+module Api
+  module V1
+    class UploadsController < ApplicationController
+      # JWT認証を必須化（ログインユーザーのみ利用可）
+      before_action :authenticate_with_jwt!
+
+      # === S3署名付きURL発行エンドポイント ===
+      # POST /api/v1/uploads/presign
+      #
+      # フロントエンドから、画像アップロード時に呼ばれるAPI
+      # 1. フロントから拡張子とファイルサイズが渡される
+      # 2. サーバー側で拡張子・サイズをバリデーション
+      # 3. S3の所定パス（uploads/cheers/{user_id}/...）で一時的なPUT用URLを生成
+      # 4. ついでにGET用の署名付きURL（プレビュー・ダウンロード用）も生成して返却
+      # 5. フロントはこのupload_urlに直接画像をPUT、public_urlで画像表示
+      def presign
+        ext = params[:ext].to_s.downcase   # ファイル拡張子
+        size = params[:size].to_i          # ファイルサイズ（バイト単位）
+        allowed_exts = %w[jpg jpeg png webp] # 許可する拡張子
+        max_size = 5.megabytes             # 最大許容サイズ（5MB）
+        max_uploads_per_day = 20  # 1ユーザー20枚/日以上はアップロード不可
+
+        # --- 拡張子・サイズバリデーション ---
+        unless allowed_exts.include?(ext)
+          render json: { error: "拡張子が不正です" }, status: :unprocessable_entity and return
+        end
+        if size > max_size
+          render json: { error: "ファイルサイズが大きすぎます（最大5MB）" }, status: :unprocessable_entity and return
+        end
+
+        # --- アップロード枚数バリデーション ---
+        today = Time.zone.today
+        uploads_today = Cheer.where(user_id: @current_user.id)
+                            .where('created_at >= ?', today)
+                            .where.not(image_url: [nil, ""])
+                            .count
+
+        if uploads_today >= max_uploads_per_day
+          render json: { error: "1日のアップロード上限（#{max_uploads_per_day}枚）に達しました" }, status: :forbidden and return
+        end
+
+        # --- S3の保存パスを決定（userごとにディレクトリ分け）---
+        uuid = SecureRandom.uuid
+        user_id = @current_user.id
+        object_key = "cheers/#{user_id}/#{uuid}.#{ext}"
+
+        # --- S3クライアントを初期化（LocalStack/本番どちらにも対応）---
+        s3 = Aws::S3::Resource.new(
+          endpoint: ENV["S3_ENDPOINT"], # LocalStackの場合はローカルエンドポイント
+          region: "ap-northeast-1",
+          access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+          secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+          force_path_style: true
+        )
+
+        # --- PUT（アップロード）用の署名付きURLを生成（10分間有効）---
+        obj = s3.bucket("uploads").object(object_key)
+        presigned_url = obj.presigned_url(:put, expires_in: 600, acl: "private", content_type: "image/#{ext}")
+
+        # --- プライベートバケット用：GET（プレビュー/表示）も署名付きURLで取得する想定 ---
+        get_url = obj.presigned_url(:get, expires_in: 600)
+
+        # --- LocalStack用ホスト名書き換え ---
+        if ENV["S3_ENDPOINT"].present? && presigned_url.include?("localstack:4566")
+          # Dockerネットワーク内だけのhost名→外部アクセス用に変換
+          upload_url = presigned_url.gsub("localstack:4566", "localhost:4566")
+          public_url = get_url.gsub("localstack:4566", "localhost:4566")
+        else
+          upload_url = presigned_url
+          public_url = get_url
+        end
+
+        # --- フロントへPUT/GET用URLを返却 ---
+        render json: { upload_url: upload_url, public_url: public_url }
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       resources :cheer_types, only: [:index]
       resources :muscles, only: [:index]
       resources :poses, only: [:index]
+      post "uploads/presign", to: "uploads#presign" #/api/v1/uploads/presignへのPOSTリクエストをApi::V1::UploadsControllerのpresignアクションにルーティング
     end
   end
 end

--- a/backend/lib/tasks/uploads.rake
+++ b/backend/lib/tasks/uploads.rake
@@ -1,0 +1,27 @@
+namespace :uploads do
+  desc "未参照のS3画像をクリーンアップ"
+  task cleanup_unused: :environment do
+    require "aws-sdk-s3"
+
+    s3 = Aws::S3::Resource.new(
+      region: ENV["AWS_REGION"] || "ap-northeast-1",
+      access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      endpoint: ENV["S3_ENDPOINT"].presence, # LocalStackなら
+      force_path_style: ENV["S3_ENDPOINT"].present?
+    )
+    bucket_name = ENV["S3_BUCKET"] || "uploads"
+
+    bucket = s3.bucket(bucket_name)
+    # 例: uploads/cheers/配下すべて
+    bucket.objects(prefix: "uploads/cheers/").each do |obj|
+      # DB（cheers.image_url）に使われているか判定
+      used = Cheer.where("image_url LIKE ?", "%#{obj.key}%").exists?
+      unless used
+        puts "削除: #{obj.key}"
+        obj.delete
+      end
+    end
+    puts "未参照ファイルのクリーンアップ完了"
+  end
+end

--- a/docker/localstack/cors.json
+++ b/docker/localstack/cors.json
@@ -1,0 +1,10 @@
+{
+  "CORSRules": [
+    {
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["GET", "PUT", "POST", "DELETE"],
+      "AllowedOrigins": ["*"],
+      "ExposeHeaders": []
+    }
+  ]
+}

--- a/docker/localstack/init-s3-buckets.sh
+++ b/docker/localstack/init-s3-buckets.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# LocalStack S3バケット作成＋CORS設定
+
+# バケット名（必要に応じて複数可）
+BUCKET=uploads
+
+# 1. バケット作成
+awslocal s3 mb s3://$BUCKET
+
+# 2. CORS設定（※ JSONは「CORSRules」形式で！）
+awslocal s3api put-bucket-cors \
+  --bucket $BUCKET \
+  --cors-configuration file:///docker-entrypoint-initaws.d/cors.json

--- a/frontend/app/cheers/page.tsx
+++ b/frontend/app/cheers/page.tsx
@@ -1,5 +1,6 @@
 // frontend/app/cheers/page.tsx
 import { getCheers, deleteCheer } from "@/lib/server/cheers";
+import { auth } from "@clerk/nextjs/server";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import CheersList from "@/components/cheer/CheersList";
@@ -7,6 +8,13 @@ import type { Cheer } from "@/lib/types/cheer";
 import { redirect } from "next/navigation";
 
 export default async function CheersPage() {
+  const { userId } = await auth();
+    // ここで未ログインならサインインページにリダイレクト
+  if (!userId) {
+    redirect("/sign-in");
+  }
+
+  //ログイン済みだけcheersを取得
   const cheers: Cheer[] = await getCheers();
 
   async function handleDelete(id: number) {

--- a/frontend/lib/hooks/useImageUploader.ts
+++ b/frontend/lib/hooks/useImageUploader.ts
@@ -1,5 +1,7 @@
 // frontend/lib/hooks/useImageUploader.ts
 import { useState } from "react";
+import { useAuthFetch } from "@/lib/hooks/useAuthFetch";
+import { getBaseUrl } from "@/lib/utils/getBaseUrl";
 
 type UploadResult = {
   uploading: boolean;
@@ -11,39 +13,87 @@ type UploadResult = {
 };
 
 export function useImageUploader(): UploadResult {
-  const [uploading, setUploading] = useState(false);
-  const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+// 画像アップロード中かどうか（ローディング状態管理）
+const [uploading, setUploading] = useState(false);
+// S3へのアップロードが完了した画像のURL（DB保存やプレビュー用に使う）
+const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
+// 画像プレビュー用のローカルURL（inputで画像選択した瞬間に表示用）
+const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+// アップロード失敗時のエラーメッセージ
+const [error, setError] = useState<string | null>(null);
+// JWT認証付きfetchラッパー（APIリクエスト用）
+const { fetchWithAuth } = useAuthFetch();
+//APIのベースURLを取得
+const API_BASE = getBaseUrl();
 
-  // inputのonChangeイベントハンドラ
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setPreviewUrl(URL.createObjectURL(file));
-    setUploading(true);
-    setError(null);
+const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const file = e.target.files?.[0];
+  if (!file) return;
+
+  // --- 拡張子バリデーション ---
+  const allowedExts = ["jpg", "jpeg", "png", "webp"];
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  if (!ext || !allowedExts.includes(ext)) {
+    setError("対応画像形式（JPG, JPEG, PNG, WEBP）のみアップロードできます");
+    return;
+  }
+
+  // --- サイズバリデーション（5MB） ---
+  const maxSize = 5 * 1024 * 1024; // 5MB
+  if (file.size > maxSize) {
+    setError("5MB以下の画像のみアップロードできます");
+    return;
+  }
+
+  setPreviewUrl(URL.createObjectURL(file));
+  setUploading(true);
+  setError(null);
+
     try {
-      // S3署名付きURL取得APIを呼ぶ（ここは自身のAPIに合わせて変更）
-      const res = await fetch("/api/upload-url");
-      if (!res.ok) throw new Error("署名付きURLの取得に失敗しました");
-      const { upload_url, public_url } = await res.json();
-      const uploadRes = await fetch(upload_url, {
-        method: "PUT",
-        body: file,
+      // 絶対パスでAPI呼び出し
+      const res = await fetchWithAuth(`${API_BASE}/api/v1/uploads/presign`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ext,
+          size: file.size,
+        }),
       });
-      if (!uploadRes.ok) throw new Error("S3へのアップロードに失敗しました");
-      setUploadedUrl(public_url);
-    } catch (err: unknown) {
-      setError(
-        err instanceof Error ? err.message : "アップロードに失敗しました"
-      );
-    } finally {
-      setUploading(false);
-    }
-  };
 
-  // 状態のリセット
+      // 失敗時はエラーメッセージ取得
+      if (!res.ok) {
+        let errorMsg = "署名付きURLの取得に失敗しました";
+        try {
+          const data = await res.json();
+          if (data && data.error) errorMsg = data.error;
+        } catch { /* ignore */ }
+        setError(errorMsg);
+        setUploading(false);
+        return;
+      }
+
+      // 成功時
+      const { upload_url, public_url } = await res.json();
+
+
+    // S3に直接PUT
+    const uploadRes = await fetch(upload_url, {
+      method: "PUT",
+      headers: { "Content-Type": file.type },
+      body: file,
+    });
+    if (!uploadRes.ok) throw new Error("S3へのアップロードに失敗しました");
+
+    setUploadedUrl(public_url);
+  } catch (err: unknown) {
+    setError(
+      err instanceof Error ? err.message : "アップロードに失敗しました"
+    );
+  } finally {
+    setUploading(false);
+  }
+};
+
   const reset = () => {
     setUploadedUrl(null);
     setPreviewUrl(null);


### PR DESCRIPTION
## セグメント9：**画像アップロード・S3（LocalStack）連携**

### **開発・本番S3の共存運用とファイルアップロードの課題**

**画像アップロード時の認可とS3直PUT運用の必要性**

- 掛け声（Cheer）データに画像を付与するため、**ユーザー認証下でS3へ直接画像を保存**する仕組みが必要
- 開発環境ではLocalStack（S3互換）、本番ではAWS S3を利用
- **署名付きURLによる直PUT方式**により、Rails APIサーバーが画像本体を経由せず、効率的かつセキュアなアップロードを実現

### **S3バケット設計・署名付きURL発行APIの実装**

**LocalStackバケット自動作成・CORS設定**

- docker-composeと初期化スクリプト（`init-s3-buckets.sh`）で**LocalStack起動時にuploadsバケットを自動生成**
- CORSポリシーも同時設定し、**フロントからのS3直接アクセスを許可**

**署名付きURL発行APIの設計（Rails側）**

- `/api/v1/uploads/presign` でJWT認証→S3署名付きURL（PUT/GET）を発行・返却
- ファイル拡張子・サイズ・1日アップロード回数等の**バリデーションをサーバー側で厳格にチェック**
- **プライベートバケット運用**のためGETも署名付きURLで返却、**画像表示時も一時的なURLでアクセス**

### **フロントエンドのアップロードUI設計**

**画像アップロードフロー**

- ユーザーが画像を選択→API経由で署名付きURL取得→**S3に直PUT（fetch）**
- PUT成功時はGET用URLを保存・プレビュー表示→cheer作成時に画像URLをDBへ保存

**バリデーション・エラーハンドリング**

- **フロント側でもファイル形式/サイズバリデーションを事前実施**し、即時エラー表示
- サーバー側バリデーションでの上限超過・不正リクエストも**エラーメッセージとして明示的にUI表示**

### **運用・保守対策**

**未参照ファイルの自動削除**

- 「アップロード後にcheer作成されなかった画像」等、**DB未参照ファイルのバッチ削除（rakeタスク）**を実装
- 環境変数連動で**本番S3・LocalStackのどちらでも同じバッチが動作**
    
    （Renderの定期ジョブで毎週自動実行）
    

**本番・開発切替の容易さ**

- S3接続情報/バケット名/エンドポイント等を**全て環境変数で吸収**
    
    （docker-compose, .env, Render管理画面で柔軟に切替）