### PR TITLE
グーグルアドセンス広告仮置き

### DIFF
--- a/frontend/app/cheers/create/page.tsx
+++ b/frontend/app/cheers/create/page.tsx
@@ -4,6 +4,7 @@ import { createCheer } from "@/lib/server/cheers";
 import CheerTabs from "@/components/cheer/CheerTabs";
 import { redirect } from "next/navigation";
 import type { CheerFormState } from "@/lib/types/cheer";
+import { AdBanner } from '@/components/ads/AdBanner'
 
 export default async function CreateCheerPage() {
   const { cheerTypes, muscles, poses } = await getCheerPresets();
@@ -23,6 +24,7 @@ export default async function CreateCheerPage() {
         poses={poses}
         onSubmit={handleSubmit}
       />
+    <AdBanner />
     </div>
   );
 }

--- a/frontend/app/cheers/page.tsx
+++ b/frontend/app/cheers/page.tsx
@@ -6,6 +6,8 @@ import { Button } from "@/components/ui/button";
 import CheersList from "@/components/cheer/CheersList";
 import type { Cheer } from "@/lib/types/cheer";
 import { redirect } from "next/navigation";
+import { AdBanner } from '@/components/ads/AdBanner'
+
 
 export default async function CheersPage() {
   const { userId } = await auth();
@@ -32,6 +34,7 @@ export default async function CheersPage() {
         </Link>
       </div>
       <CheersList cheers={cheers} onDelete={handleDelete} />
+      <AdBanner />
     </div>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -10,6 +10,7 @@ import {
 import type { Metadata } from "next";
 import "./globals.css";
 import { Toaster } from "sonner";
+import Script from 'next/script'
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -20,6 +21,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <ClerkProvider>
       <html lang="ja">
+        <head>
+          <Script
+            async
+            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
+            strategy="afterInteractive"
+            crossOrigin="anonymous"
+          />
+        </head>
         <body>
           <header>
             <SignedOut>

--- a/frontend/components/ads/AdBanner.tsx
+++ b/frontend/components/ads/AdBanner.tsx
@@ -1,0 +1,36 @@
+// app/components/ads/AdBanner.tsx
+'use client'
+
+import { useEffect } from 'react'
+
+export function AdBanner() {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      try {
+        // @ts-expect-error: adsbygoogle は外部スクリプトで動的に提供されるグローバル変数
+        (window.adsbygoogle = window.adsbygoogle || []).push({})
+      } catch (e) {
+        console.error('AdSense Error:', e)
+      }
+    }
+  }, [])
+
+  if (process.env.NODE_ENV !== 'production') {
+    return (
+      <div className="bg-gray-100 text-center py-4 rounded text-sm text-gray-500">
+        [ここに広告が表示されます（開発用プレースホルダー）]
+      </div>
+    )
+  }
+
+  return (
+    <ins
+      className="adsbygoogle block"
+      style={{ display: 'block' }}
+      data-ad-client={process.env.NEXT_PUBLIC_AD_CLIENT_ID}
+      data-ad-slot={process.env.NEXT_PUBLIC_AD_SLOT_ID}
+      data-ad-format="auto"
+      data-full-width-responsive="true"
+    />
+  )
+}


### PR DESCRIPTION
- **広告コンポーネント用ディレクトリ作成**
    
    → `components/ads/AdBanner.tsx` に設置（将来の拡張を考慮）
    
- **Google AdSenseスクリプトをレイアウトに読み込み**
    
    → `app/layout.tsx` の `<head>` に `<Script>` を追加
    
    → `strategy="afterInteractive"` で読み込み最適化
    
- **開発/本番の環境分岐に対応した AdBanner.tsx 実装**
    
    → `.env.production` で `NEXT_PUBLIC_AD_CLIENT_ID` / `AD_SLOT_ID` を管理
    
    → 開発時はプレースホルダ表示、本番でのみ実広告表示
    
- **ESLintの `@ts-expect-error` 警告に対応**
    
    → `// @ts-expect-error: adsbygoogle は外部スクリプト由来` のように**説明付きで記述**
    
- **広告表示位置の方針決定**
    - `/cheers`：カード一覧の末尾
    - `/cheers/create`：タブ下（生成フォームの邪魔にならない位置）
    - 1画面1枠までに制限
- **Tailwindでスマホ/PCの表示切り替えも可能な設計**