### PR TITLE
clerkの表示内容変更

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 // frontend/app/layout.tsx
 import { ClerkProvider } from "@clerk/nextjs";
+import { jaJP } from "@clerk/localizations";
 import type { Metadata } from "next";
 import "./globals.css";
 import { Toaster } from "sonner";
@@ -14,25 +15,33 @@ export const metadata: Metadata = {
   description: "筋肉と掛け声のSNS",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
-    <ClerkProvider>
-      <html lang="ja">
+    <ClerkProvider
+      localization={jaJP}
+      signInUrl='/sign-in'
+      signUpUrl='/sign-up'
+    >
+      <html lang='ja'>
         <head>
           <Script
             async
-            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
-            strategy="afterInteractive"
-            crossOrigin="anonymous"
+            src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'
+            strategy='afterInteractive'
+            crossOrigin='anonymous'
           />
         </head>
         <body>
-          <div className="flex w-full justify-center">
-            <div className="flex w-full max-w-screen-md min-h-screen gap-0">
-              <aside className="hidden md:block w-52 shrink-0">
+          <div className='flex w-full justify-center'>
+            <div className='flex w-full max-w-screen-md min-h-screen gap-0'>
+              <aside className='hidden md:block w-52 shrink-0'>
                 <SideNav />
               </aside>
-              <main className="flex-1">
+              <main className='flex-1'>
                 <AppHeader />
                 {children}
               </main>
@@ -40,7 +49,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </div>
           <BottomNav />
           <FloatingCreateButton />
-          <Toaster richColors closeButton position="top-center" />
+          <Toaster richColors closeButton position='top-center' />
         </body>
       </html>
     </ClerkProvider>

--- a/frontend/app/sign-in/[[...rest]]/page.tsx
+++ b/frontend/app/sign-in/[[...rest]]/page.tsx
@@ -1,5 +1,32 @@
-// app/sign-in/page.tsx
+// app/sign-in/[[...rest]]/page.tsx
 import { SignIn } from "@clerk/nextjs";
+
 export default function Page() {
-  return <SignIn />;
+  return (
+    <SignIn
+      appearance={{
+        elements: {
+          card: "bg-card text-foreground shadow-md border border-border rounded-xl px-6 py-4",
+          headerTitle: "text-xl font-bold text-foreground",
+          headerSubtitle: "text-sm text-muted",
+          socialButtonsBlockButton:
+            "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
+          formButtonPrimary:
+            "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
+          formFieldInput:
+            "bg-white border border-border rounded-md px-3 py-2 text-sm",
+          formFieldLabel: "text-sm text-foreground",
+          footerActionText: "text-sm text-muted",
+          footerActionLink:
+            "text-sm text-primary underline hover:text-primary/80",
+        },
+        variables: {
+          colorPrimary: "#ff6b81",
+          colorBackground: "#f9fafb",
+          colorText: "#1e1e1e",
+          colorTextSecondary: "#6b7280",
+        },
+      }}
+    />
+  );
 }

--- a/frontend/app/sign-up/[[...rest]]/page.tsx
+++ b/frontend/app/sign-up/[[...rest]]/page.tsx
@@ -1,5 +1,32 @@
-// app/sign-up/page.tsx
+// app/sign-up/[[...rest]]/page.tsx
 import { SignUp } from "@clerk/nextjs";
+
 export default function Page() {
-  return <SignUp />;
+  return (
+    <SignUp
+      appearance={{
+        elements: {
+          card: "bg-card text-foreground shadow-md border border-border rounded-xl px-6 py-4",
+          headerTitle: "text-xl font-bold text-foreground",
+          headerSubtitle: "text-sm text-muted",
+          socialButtonsBlockButton:
+            "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
+          formButtonPrimary:
+            "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
+          formFieldInput:
+            "bg-white border border-border rounded-md px-3 py-2 text-sm",
+          formFieldLabel: "text-sm text-foreground",
+          footerActionText: "text-sm text-muted",
+          footerActionLink:
+            "text-sm text-primary underline hover:text-primary/80",
+        },
+        variables: {
+          colorPrimary: "#ff6b81",
+          colorBackground: "#f9fafb",
+          colorText: "#1e1e1e",
+          colorTextSecondary: "#6b7280",
+        },
+      }}
+    />
+  );
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@clerk/clerk-react": "^5.31.8",
         "@clerk/clerk-sdk-node": "^4.13.23",
+        "@clerk/localizations": "^3.16.4",
         "@clerk/nextjs": "^6.21.0",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -270,6 +271,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@clerk/localizations": {
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/@clerk/localizations/-/localizations-3.16.4.tgz",
+      "integrity": "sha512-tIBNVtd1PvJVs+8/hMDobOtg6LW7sYpMczu+TlNvoxyQUbUzWzFCso2Tue+TekXDmgYlXH+jVbnYq4XbIi2rdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "^4.60.0"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@clerk/nextjs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@clerk/clerk-react": "^5.31.8",
     "@clerk/clerk-sdk-node": "^4.13.23",
+    "@clerk/localizations": "^3.16.4",
     "@clerk/nextjs": "^6.21.0",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",


### PR DESCRIPTION
Clerk認証画面のUIをムキメンタリーデザインにカスタマイズ

@clerk/localizations で日本語化（jaJP）を導入

ClerkProvider に signInUrl / signUpUrl を指定して .accounts.dev 遷移を防止

appearance.elements でTailwindクラスを適用（カード・ボタン等）

appearance.variables はCSS変数不可のため HEXカラーで指定（例：#ff6b81）

/sign-in, /sign-up は App Router ([[...rest]]) 構成で対応