### PR TITLE
clerkの表示内容変更2

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 // frontend/app/layout.tsx
 import { ClerkProvider } from "@clerk/nextjs";
+import { clerkAppearance } from "@/lib/clerk/appearance";
 import { jaJP } from "@clerk/localizations";
 import type { Metadata } from "next";
 import "./globals.css";
@@ -7,7 +8,6 @@ import { Toaster } from "sonner";
 import Script from "next/script";
 import SideNav from "@/components/layout/SideNav";
 import BottomNav from "@/components/layout/BottomNav";
-import { FloatingCreateButton } from "@/components/cheer/FloatingCreateButton";
 import AppHeader from "@/components/layout/AppHeader";
 
 export const metadata: Metadata = {
@@ -25,6 +25,7 @@ export default function RootLayout({
       localization={jaJP}
       signInUrl='/sign-in'
       signUpUrl='/sign-up'
+      appearance={clerkAppearance}
     >
       <html lang='ja'>
         <head>
@@ -48,7 +49,6 @@ export default function RootLayout({
             </div>
           </div>
           <BottomNav />
-          <FloatingCreateButton />
           <Toaster richColors closeButton position='top-center' />
         </body>
       </html>

--- a/frontend/app/sign-in/[[...rest]]/page.tsx
+++ b/frontend/app/sign-in/[[...rest]]/page.tsx
@@ -2,31 +2,5 @@
 import { SignIn } from "@clerk/nextjs";
 
 export default function Page() {
-  return (
-    <SignIn
-      appearance={{
-        elements: {
-          card: "bg-card text-foreground shadow-md border border-border rounded-xl px-6 py-4",
-          headerTitle: "text-xl font-bold text-foreground",
-          headerSubtitle: "text-sm text-muted",
-          socialButtonsBlockButton:
-            "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
-          formButtonPrimary:
-            "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
-          formFieldInput:
-            "bg-white border border-border rounded-md px-3 py-2 text-sm",
-          formFieldLabel: "text-sm text-foreground",
-          footerActionText: "text-sm text-muted",
-          footerActionLink:
-            "text-sm text-primary underline hover:text-primary/80",
-        },
-        variables: {
-          colorPrimary: "#ff6b81",
-          colorBackground: "#f9fafb",
-          colorText: "#1e1e1e",
-          colorTextSecondary: "#6b7280",
-        },
-      }}
-    />
-  );
+  return <SignIn />;
 }

--- a/frontend/app/sign-up/[[...rest]]/page.tsx
+++ b/frontend/app/sign-up/[[...rest]]/page.tsx
@@ -2,31 +2,5 @@
 import { SignUp } from "@clerk/nextjs";
 
 export default function Page() {
-  return (
-    <SignUp
-      appearance={{
-        elements: {
-          card: "bg-card text-foreground shadow-md border border-border rounded-xl px-6 py-4",
-          headerTitle: "text-xl font-bold text-foreground",
-          headerSubtitle: "text-sm text-muted",
-          socialButtonsBlockButton:
-            "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
-          formButtonPrimary:
-            "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
-          formFieldInput:
-            "bg-white border border-border rounded-md px-3 py-2 text-sm",
-          formFieldLabel: "text-sm text-foreground",
-          footerActionText: "text-sm text-muted",
-          footerActionLink:
-            "text-sm text-primary underline hover:text-primary/80",
-        },
-        variables: {
-          colorPrimary: "#ff6b81",
-          colorBackground: "#f9fafb",
-          colorText: "#1e1e1e",
-          colorTextSecondary: "#6b7280",
-        },
-      }}
-    />
-  );
+  return <SignUp />;
 }

--- a/frontend/components/layout/AppHeader.tsx
+++ b/frontend/components/layout/AppHeader.tsx
@@ -1,36 +1,42 @@
 // frontend/components/layout/AppHeader.tsx
 "use client";
 
-import { SignedIn, SignedOut, SignInButton, SignUpButton, UserButton } from "@clerk/nextjs";
+import {
+  SignedIn,
+  SignedOut,
+  SignInButton,
+  SignUpButton,
+  UserButton,
+} from "@clerk/nextjs";
 import Link from "next/link";
 
 export default function AppHeader() {
   return (
-    <header className="md:hidden h-14 border-b border-card-border bg-background text-foreground w-full">
-      <div className="max-w-screen-lg mx-auto px-4 h-full flex items-center justify-between">
-        <Link href="/" className="text-lg font-bold text-accent">
+    <header className='md:hidden h-14 border-b border-card-border bg-background text-foreground w-full'>
+      <div className='max-w-screen-lg mx-auto px-4 h-full flex items-center justify-between'>
+        <Link href='/' className='text-lg font-bold text-accent'>
           Mukimentary
         </Link>
 
-        <div className="space-x-2">
+        <div className='flex items-center gap-2 text-sm'>
           <SignedOut>
-            <SignInButton mode="modal">
-              <button className="text-sm text-subtext hover:text-accent transition">
+            <SignInButton mode='modal'>
+              <button className='text-sm text-white bg-primary px-3 py-1.5 rounded-md hover:bg-primary/90 transition'>
                 ログイン
               </button>
             </SignInButton>
-            <SignUpButton mode="modal">
-              <button className="text-sm text-subtext hover:text-accent transition">
+            <SignUpButton mode='modal'>
+              <button className='text-sm text-white bg-primary px-3 py-1.5 rounded-md hover:bg-primary/90 transition'>
                 新規登録
               </button>
             </SignUpButton>
           </SignedOut>
+
           <SignedIn>
-            <UserButton afterSignOutUrl="/" />
+            <UserButton afterSignOutUrl='/' />
           </SignedIn>
         </div>
       </div>
     </header>
   );
 }
-

--- a/frontend/components/layout/BottomNav.tsx
+++ b/frontend/components/layout/BottomNav.tsx
@@ -19,7 +19,15 @@ export default function BottomNav() {
   const profileHref = user?.username ? `/profile/${user.username}` : "/profile";
 
   return (
-    <nav className="fixed bottom-0 left-0 w-full h-14 bg-[hsl(var(--background))] border-t border-[hsl(var(--card-border))] flex justify-around items-center md:hidden z-40 text-[hsl(var(--foreground))]">
+    <nav
+      className='fixed bottom-0 left-0 w-full h-14
+  bg-primary text-white
+  border-t border-[hsl(var(--card-border))]
+  shadow-[0_-2px_6px_rgba(0,0,0,0.1)]
+  flex justify-around items-center
+  md:hidden z-40'
+    >
+      {" "}
       {navItems.map(({ href, icon: Icon, label }) => {
         const isActive = pathname.startsWith(href);
         return (
@@ -27,15 +35,16 @@ export default function BottomNav() {
             key={href}
             href={href}
             className={`flex flex-col items-center text-xs ${
-              isActive ? "text-[hsl(var(--accent))] font-semibold" : "text-subtext"
+              isActive
+                ? "text-[hsl(var(--accent))] font-semibold"
+                : "text-subtext"
             } hover:text-[hsl(var(--accent))] transition-colors`}
           >
-            <Icon className="w-5 h-5 mb-0.5" />
+            <Icon className='w-5 h-5 mb-0.5' />
             {label}
           </Link>
         );
       })}
-
       <Link
         href={profileHref}
         className={`flex flex-col items-center text-xs ${
@@ -44,7 +53,7 @@ export default function BottomNav() {
             : "text-subtext"
         } hover:text-[hsl(var(--accent))] transition-colors`}
       >
-        <User className="w-5 h-5 mb-0.5" />
+        <User className='w-5 h-5 mb-0.5' />
         プロフ
       </Link>
     </nav>

--- a/frontend/components/layout/SideNav.tsx
+++ b/frontend/components/layout/SideNav.tsx
@@ -1,10 +1,26 @@
 // frontend/components/layout/SideNav.tsx
 "use client";
 
-import { Home, Dumbbell, BookOpen, User, Plus } from "lucide-react";
+import {
+  Home,
+  Dumbbell,
+  BookOpen,
+  User,
+  Plus,
+  LogIn,
+  LogOut,
+  UserPlus,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useUser } from "@clerk/nextjs";
+import {
+  SignInButton,
+  SignUpButton,
+  SignedIn,
+  SignedOut,
+  useClerk,
+  useUser,
+} from "@clerk/nextjs";
 
 const navItems = [
   { href: "/cheers", icon: Home, label: "ホーム" },
@@ -16,24 +32,59 @@ const navItems = [
 export default function SideNav() {
   const pathname = usePathname();
   const { user } = useUser();
+  const { signOut } = useClerk();
 
   const profileHref = user?.username ? `/profile/${user.username}` : "/profile";
 
   return (
-    <aside className="hidden md:flex flex-col w-52 h-screen bg-[hsl(var(--background))] px-4 py-6 text-[hsl(var(--foreground))]">
-      <h1 className="text-xl font-bold mb-8 text-[hsl(var(--accent))]">Mukimentary</h1>
-      <nav className="flex flex-col gap-4">
+    <aside className='hidden md:flex flex-col w-52 h-screen bg-[hsl(var(--background))] px-4 py-6 text-[hsl(var(--foreground))]'>
+      <h1 className='text-xl font-bold mb-6 text-[hsl(var(--accent))]'>
+        Mukimentary
+      </h1>
+
+      {/* ログイン/登録/ログアウト */}
+      <div className='mb-4 flex flex-col gap-3 text-sm'>
+        <SignedOut>
+          <SignInButton mode='modal'>
+            <button className='flex items-center gap-3 hover:text-accent transition-colors text-subtext underline underline-offset-2'>
+              <LogIn className='w-5 h-5' />
+              ログイン
+            </button>
+          </SignInButton>
+          <SignUpButton mode='modal'>
+            <button className='flex items-center gap-3 hover:text-accent transition-colors text-subtext underline underline-offset-2'>
+              <UserPlus className='w-5 h-5' />
+              登録
+            </button>
+          </SignUpButton>
+        </SignedOut>
+
+        <SignedIn>
+          <button
+            onClick={() => signOut()}
+            className='flex items-center gap-3 hover:text-accent transition-colors text-subtext underline underline-offset-2'
+          >
+            <LogOut className='w-5 h-5' />
+            ログアウト
+          </button>
+        </SignedIn>
+      </div>
+
+      {/* メインメニュー */}
+      <nav className='flex flex-col gap-3 text-sm'>
         {navItems.map(({ href, icon: Icon, label }) => {
           const isActive = pathname === href;
           return (
             <Link
               key={href}
               href={href}
-              className={`flex items-center gap-3 text-sm ${
-                isActive ? "text-[hsl(var(--accent))] font-semibold" : "text-subtext"
+              className={`flex items-center gap-3 ${
+                isActive
+                  ? "text-[hsl(var(--accent))] font-semibold"
+                  : "text-subtext"
               } hover:text-[hsl(var(--accent))] transition-colors`}
             >
-              <Icon className="w-5 h-5" />
+              <Icon className='w-5 h-5' />
               {label}
             </Link>
           );
@@ -41,13 +92,13 @@ export default function SideNav() {
 
         <Link
           href={profileHref}
-          className={`flex items-center gap-3 text-sm ${
+          className={`flex items-center gap-3 ${
             pathname.startsWith("/profile")
               ? "text-[hsl(var(--accent))] font-semibold"
               : "text-subtext"
           } hover:text-[hsl(var(--accent))] transition-colors`}
         >
-          <User className="w-5 h-5" />
+          <User className='w-5 h-5' />
           プロフ
         </Link>
       </nav>

--- a/frontend/lib/clerk/appearance.ts
+++ b/frontend/lib/clerk/appearance.ts
@@ -1,0 +1,25 @@
+// lib/clerk/appearance.ts
+import type { Appearance } from "@clerk/types";
+
+export const clerkAppearance: Appearance = {
+  elements: {
+    card: "bg-card text-foreground shadow-md border border-border rounded-xl px-6 py-4",
+    headerTitle: "text-xl font-bold text-foreground",
+    headerSubtitle: "text-sm text-muted",
+    socialButtonsBlockButton:
+      "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
+    formButtonPrimary:
+      "bg-primary text-white rounded-md hover:bg-primary/90 transition-all",
+    formFieldInput:
+      "bg-white border border-border rounded-md px-3 py-2 text-sm",
+    formFieldLabel: "text-sm text-foreground",
+    footerActionText: "text-sm text-muted",
+    footerActionLink: "text-sm text-primary underline hover:text-primary/80",
+  },
+  variables: {
+    colorPrimary: "#ff6b81",
+    colorBackground: "#f9fafb",
+    colorText: "#1e1e1e",
+    colorTextSecondary: "#6b7280",
+  },
+};


### PR DESCRIPTION
Clerkのログイン・新規登録モーダルのUIをTailwindベースにデザインカスタマイズ

clerkAppearance.ts を新規作成し、SignIn / SignUp に共通デザインを適用

サインイン／サインアップページ（/sign-in, /sign-up）を App Router で独自ルーティング対応

モバイル用 AppHeader.tsx にログイン・登録モーダルボタンを設置

ボタンデザインは bg-primary＋白文字で BottomNav に合わせた配色に統一

ClerkProvider に localization={jaJP} を追加し、日本語化を有効化

signInUrl / signUpUrl を /sign-in / /sign-up に指定し .accounts.dev への遷移を防止