### PR TITLE
画像見える化

### DIFF
--- a/frontend/components/cheer/CheerCard.tsx
+++ b/frontend/components/cheer/CheerCard.tsx
@@ -1,7 +1,6 @@
 //frontend/components/cheer/CheerCard.tsx
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Share2 } from "lucide-react";
@@ -32,11 +31,11 @@ export function CheerCard({ cheer, onDelete }: Props) {
       {/* 画像 */}
       {cheer.image_url && (
         <div className='w-full aspect-[4/3] relative rounded-md overflow-hidden border'>
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             src={cheer.image_url}
             alt='掛け声画像'
-            fill
-            className='object-contain'
+            className='w-full h-full object-contain absolute inset-0'
           />
         </div>
       )}


### PR DESCRIPTION
next/imageの使用から

{/* eslint-disable-next-line @next/next/no-img-element */}
<img
  src={cheer.image_url}
  alt='掛け声画像'
  className='w-full h-full object-contain absolute inset-0'
/>

にして 署名付きURLは処理できず、400エラーになる（S3の署名が壊れる）から
ブラウザがS3のURLをそのまま使うので署名が有効に保たれ、画像が正しく表示されるように