### PR TITLE
cheerのフォーム周りのリファクタリング実施

### DIFF
--- a/frontend/components/cheer/forms/CheerAiForm.tsx
+++ b/frontend/components/cheer/forms/CheerAiForm.tsx
@@ -3,20 +3,24 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { GenerateCountInfo } from "@/components/cheer/ui/GenerateCountInfo";
 import type { CheerType, Muscle, Pose } from "@/lib/types/prests";
-import type { CheerFormState } from "@/lib/types/cheer";
+import type { CheerFormState,FormState } from "@/lib/types/cheer";
 import { useCheerApi } from "@/lib/hooks/useCheerApi";
+import { GenerateCountInfo } from "@/components/cheer/ui/GenerateCountInfo";
+import { CheerSelectField } from "@/components/cheer/forms/common/CheerSelectField";
+import { CheerKeywordInput } from "@/components/cheer/forms/common/CheerKeywordInput";
+import { CheerTextInput } from "@/components/cheer/forms/common/CheerTextInput";
 
 type Props = {
-  cheerTypes: CheerType[];
-  muscles: Muscle[];
-  poses: Pose[];
-  onSubmit: (form: CheerFormState) => void | Promise<void>;
-  remaining: number | null;
-  onChangeRemaining: (n: number | null) => void;
+  cheerTypes: CheerType[];                     // 掛け声タイプの選択肢
+  muscles: Muscle[];                           // 筋肉部位の選択肢
+  poses: Pose[];                               // ポーズの選択肢
+  onSubmit: (form: CheerFormState) => void | Promise<void>; // フォーム送信時の処理
+  remaining: number | null;                    // 残り生成回数（nullの場合は未取得）
+  onChangeRemaining: (value: number | null) => void; // 残り使用回数の更新用コールバック
 };
 
+//テキストAIを用いて掛け声を生成するフォーム
 export default function CheerAiForm({
   cheerTypes,
   muscles,
@@ -25,198 +29,147 @@ export default function CheerAiForm({
   remaining,
   onChangeRemaining,
 }: Props) {
-  const [form, setForm] = useState<{
-    cheerTypeId: number | "";
-    muscleId: number | "";
-    poseId: number | "";
-    keyword?: string;
-  }>({
+  // 入力フィールドの状態管理（cheerTypeId, muscleId, poseId は number または空文字）
+  const [form, setForm] = useState<FormState>({
     cheerTypeId: "",
     muscleId: "",
     poseId: "",
     keyword: "",
   });
 
+  // 結果やエラーの状態を管理
   const [result, setResult] = useState<string>("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
   const { generateCheer } = useCheerApi();
 
-  const handleChange = <K extends keyof typeof form>(
-    key: K,
-    value: (typeof form)[K]
-  ) => {
+  /**
+   * フォーム入力変更時のハンドラー（型安全に）
+   */
+  const handleChange = <K extends keyof FormState>(key: K, value: FormState[K]) => {
     setForm((prev) => ({ ...prev, [key]: value }));
   };
 
+  /**
+   * AIにより掛け声を生成する処理
+   */
   const handleGenerate = async () => {
     setLoading(true);
     setError(null);
     setResult("");
     try {
       const res = await generateCheer({
-        cheer_type: cheerTypes.find((t) => t.id === form.cheerTypeId)?.name,
-        muscle: muscles.find((m) => m.id === form.muscleId)?.name,
-        pose: poses.find((p) => p.id === form.poseId)?.name,
+        cheer_type: cheerTypes.find((t) => t.id === Number(form.cheerTypeId))?.name,
+        muscle: muscles.find((m) => m.id === Number(form.muscleId))?.name,
+        pose: poses.find((p) => p.id === Number(form.poseId))?.name,
         keyword: form.keyword,
       });
+      if ("remaining" in res && typeof res.remaining === "number") {
+        onChangeRemaining(res.remaining);
+      }
       if (res.result) setResult(res.result);
       if (res.error) setError(res.error);
     } catch (e: unknown) {
-      setError(
-        e instanceof Error
-          ? e.message || "生成に失敗しました"
-          : "生成に失敗しました"
-      );
+      if (e instanceof Error) {
+        setError(e.message || "生成に失敗しました");
+      } else {
+        setError("生成に失敗しました");
+      }
     } finally {
       setLoading(false);
     }
   };
 
+  /**
+   * 掛け声を保存する処理
+   */
   const handleSave = async () => {
     if (!result) return;
     await onSubmit({
       text: result,
-      cheerTypeId: form.cheerTypeId,
-      muscleId: form.muscleId,
-      poseId: form.poseId,
-      keyword: form.keyword || "",
+      cheerTypeId: Number(form.cheerTypeId),
+      muscleId: Number(form.muscleId),
+      poseId: Number(form.poseId),
+      keyword: form.keyword,
+      imageUrl: null,
       cheerMode: "ai",
     });
   };
 
   return (
-    <div className='bg-card border border-border rounded-xl shadow-sm p-5 max-w-lg mx-auto space-y-5'>
-      <h2 className='text-xl font-bold text-center text-foreground'>
-        キーワードからAIで掛け声を生成
+    <div className="bg-card border border-border rounded-xl shadow-sm p-5 max-w-lg mx-auto space-y-5">
+      <h2 className="text-xl font-bold text-center text-foreground">
+        テキストとキーワードからAIで掛け声を生成
       </h2>
 
-      <GenerateCountInfo kind='text_ai' onChangeRemaining={onChangeRemaining} />
+      <GenerateCountInfo kind="text_ai" onChangeRemaining={onChangeRemaining} />
 
-      {/* タイプ */}
-      <div className='space-y-1'>
-        <label className='text-sm font-medium text-muted-foreground'>
-          タイプ(任意)
-        </label>
-        <select
-          value={form.cheerTypeId}
-          onChange={(e) =>
-            handleChange(
-              "cheerTypeId",
-              e.target.value === "" ? "" : Number(e.target.value)
-            )
-          }
-          className='w-full rounded-lg border border-input bg-white px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-ring'
-          required
-        >
-          <option value=''>選択してください</option>
-          {cheerTypes.map((type) => (
-            <option key={type.id} value={type.id}>
-              {type.name}（{type.description}）
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* 選択フィールド */}
+      <CheerSelectField
+        label="タイプ（任意）"
+        value={form.cheerTypeId}
+        onChange={(val) => handleChange("cheerTypeId", val)}
+        options={cheerTypes.map((c) => ({
+          value: c.id,
+          label: `${c.name}（${c.description}）`,
+        }))}
+      />
+      <CheerSelectField
+        label="筋肉部位（任意）"
+        value={form.muscleId}
+        onChange={(val) => handleChange("muscleId", val)}
+        options={muscles.map((m) => ({
+          value: m.id,
+          label: `${m.name}（${m.description}）`,
+        }))}
+      />
+      <CheerSelectField
+        label="ポーズ（任意）"
+        value={form.poseId}
+        onChange={(val) => handleChange("poseId", val)}
+        options={poses.map((p) => ({
+          value: p.id,
+          label: `${p.name}（${p.description}）`,
+        }))}
+      />
 
-      {/* 筋肉部位 */}
-      <div className='space-y-1'>
-        <label className='text-sm font-medium text-muted-foreground'>
-          筋肉部位(任意)
-        </label>
-        <select
-          value={form.muscleId}
-          onChange={(e) =>
-            handleChange(
-              "muscleId",
-              e.target.value === "" ? "" : Number(e.target.value)
-            )
-          }
-          className='w-full rounded-lg border border-input bg-white px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-ring'
-          required
-        >
-          <option value=''>選択してください</option>
-          {muscles.map((muscle) => (
-            <option key={muscle.id} value={muscle.id}>
-              {muscle.name}（{muscle.description}）
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* キーワード入力 */}
+      <CheerKeywordInput value={form.keyword} onChange={(val) => handleChange("keyword", val)} />
 
-      {/* ポーズ */}
-      <div className='space-y-1'>
-        <label className='text-sm font-medium text-muted-foreground'>
-          ポーズ(任意)
-        </label>
-        <select
-          value={form.poseId}
-          onChange={(e) =>
-            handleChange(
-              "poseId",
-              e.target.value === "" ? "" : Number(e.target.value)
-            )
-          }
-          className='w-full rounded-lg border border-input bg-white px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-ring'
-          required
-        >
-          <option value=''>選択してください</option>
-          {poses.map((pose) => (
-            <option key={pose.id} value={pose.id}>
-              {pose.name}（{pose.description}）
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* キーワード */}
-      <div className='space-y-1'>
-        <label className='text-sm font-medium text-muted-foreground'>
-          フリーワード(任意)
-        </label>
-        <input
-          type='text'
-          maxLength={50}
-          value={form.keyword}
-          onChange={(e) => handleChange("keyword", e.target.value)}
-          className='w-full rounded-lg border border-input bg-white px-3 py-2 text-sm placeholder:text-muted-foreground'
-          placeholder='例：流行語・アニメ名 など(50文字以内)'
-        />
-      </div>
-
-      {/* 生成ボタン */}
+      {/* 掛け声生成ボタン */}
       <Button
-        type='button'
+        type="button"
         onClick={handleGenerate}
         disabled={loading || typeof remaining !== "number" || remaining === 0}
-        className='w-full rounded-xl text-base py-2'
+        className="w-full rounded-xl text-base py-2"
       >
         {loading ? "生成中..." : "AIで掛け声生成"}
       </Button>
 
-      {/* 結果 */}
+      {/* 結果表示と編集 */}
       {result && (
-        <div className='space-y-1 mt-4'>
-          <label className='text-sm font-medium text-muted-foreground'>
+        <div className="space-y-1">
+          <label className="text-sm font-medium text-muted-foreground">
             生成結果（編集可）
           </label>
-          <textarea
-            className='w-full rounded-lg border border-input bg-white px-3 py-2 text-sm resize-none'
-            rows={2}
+          <CheerTextInput
+            label="掛け声テキスト"
             value={result}
-            onChange={(e) => setResult(e.target.value)}
+            onChange={(val) => setResult(val)}
           />
           <Button
-            type='button'
+            type="button"
             onClick={handleSave}
-            className='w-full rounded-xl text-base py-2 mt-2'
+            className="w-full rounded-xl text-base py-2 mt-2"
           >
             この内容で保存
           </Button>
         </div>
       )}
 
-      {/* エラー */}
-      {error && <div className='text-sm text-red-600'>{error}</div>}
+      {/* エラー表示 */}
+      {error && <div className="text-sm text-red-600">{error}</div>}
     </div>
   );
 }

--- a/frontend/components/cheer/forms/CheerManualForm.tsx
+++ b/frontend/components/cheer/forms/CheerManualForm.tsx
@@ -1,36 +1,56 @@
-//frontend/components/cheer/forms/CheerManualForm.tsx
+// frontend/components/cheer/forms/CheerManualForm.tsx
 "use client";
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { CheerTextInput } from "@/components/cheer/forms/common/CheerTextInput";
+import { CheerSelectField } from "@/components/cheer/forms/common/CheerSelectField";
 import type { CheerType, Muscle, Pose } from "@/lib/types/prests";
 import type { CheerFormState } from "@/lib/types/cheer";
 
+/**
+ * このフォームコンポーネントの Props（外部から渡される値）の型定義
+ */
 type Props = {
-  cheerTypes: CheerType[];
-  muscles: Muscle[];
-  poses: Pose[];
-  onSubmit: (form: CheerFormState) => void | Promise<void>;
+  cheerTypes: CheerType[]; // 掛け声のタイプ一覧（現在は未使用だが将来的な拡張のため残す）
+  muscles: Muscle[];        // 筋肉部位の一覧
+  poses: Pose[];            // ポーズの一覧
+  onSubmit: (form: CheerFormState) => void | Promise<void>; // フォーム送信時に実行される処理
 };
 
-export default function CheerManualForm({
-  muscles,
-  poses,
-  onSubmit,
-}: Props) {
+/**
+ * 手動で掛け声を作成するためのフォームコンポーネント
+ */
+export default function CheerManualForm({ muscles, poses, onSubmit }: Props) {
+  /**
+   * 入力されたフォームの状態（テキストや選択内容など）を管理するステート
+   */
   const [form, setForm] = useState<CheerFormState>({
     text: "",
-    cheerTypeId: "",
+    cheerTypeId: "", // 手動では使わないが型として必要なため初期値で保持
     muscleId: "",
     poseId: "",
-    cheerMode: "manual",
+    cheerMode: "manual", // このフォームは手動作成なので常に "manual"
   });
+
+  /**
+   * 入力内容に関するバリデーションエラーなどを表示するためのステート
+   */
   const [error, setError] = useState<string | null>(null);
 
-  const handleChange = <K extends keyof CheerFormState>(key: K, value: CheerFormState[K]) => {
+  /**
+   * フォームの各フィールドが変更されたときに状態を更新する関数
+   * @param key - 更新するフィールド名（text, muscleId, poseIdなど）
+   * @param value - 入力または選択された値
+   */
+  const handleChange = (key: keyof CheerFormState, value: string | number) => {
     setForm((prev) => ({ ...prev, [key]: value }));
   };
 
+  /**
+   * フォームが送信されたときの処理
+   * バリデーション（文字数チェック）を行い、問題なければ onSubmit を呼ぶ
+   */
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -48,62 +68,43 @@ export default function CheerManualForm({
       onSubmit={handleSubmit}
       className="bg-card border border-border rounded-xl shadow-sm p-5 max-w-lg mx-auto space-y-5"
     >
-      <h2 className="text-xl font-bold text-center text-foreground">手動で掛け声を作成</h2>
+      <h2 className="text-xl font-bold text-center text-foreground">
+        手動で掛け声を作成
+      </h2>
 
-      {/* 掛け声テキスト */}
-      <div className="space-y-1">
-        <label className="text-sm font-medium text-muted-foreground">
-          掛け声テキスト
-        </label>
-        <input
-          type="text"
-          value={form.text}
-          maxLength={50}
-          onChange={(e) => handleChange("text", e.target.value)}
-          className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          placeholder="例：背中にでっかいジープ乗せてんのかい!!"
-          required
-        />
-      </div>
+      {/* 掛け声のテキスト入力欄 */}
+      <CheerTextInput
+        label="掛け声テキスト"
+        value={form.text}
+        onChange={(val) => handleChange("text", val)}
+      />
 
-      {/* 筋肉（任意） */}
-      <div className="space-y-1">
-        <label className="text-sm font-medium text-muted-foreground">筋肉部位（任意）</label>
-        <select
-          value={form.muscleId}
-          onChange={(e) => handleChange("muscleId", e.target.value === "" ? "" : Number(e.target.value))}
-          className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-        >
-          <option value="">選択してください</option>
-          {muscles.map((muscle) => (
-            <option key={muscle.id} value={muscle.id}>
-              {muscle.name}（{muscle.description}）
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* 筋肉部位のセレクトボックス（任意） */}
+      <CheerSelectField
+        label="筋肉部位（任意）"
+        value={form.muscleId}
+        onChange={(val) => handleChange("muscleId", val)}
+        options={muscles.map((m) => ({
+          value: m.id,
+          label: `${m.name}（${m.description}）`,
+        }))}
+      />
 
-      {/* ポーズ（任意） */}
-      <div className="space-y-1">
-        <label className="text-sm font-medium text-muted-foreground">ポーズ（任意）</label>
-        <select
-          value={form.poseId}
-          onChange={(e) => handleChange("poseId", e.target.value === "" ? "" : Number(e.target.value))}
-          className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-        >
-          <option value="">選択してください</option>
-          {poses.map((pose) => (
-            <option key={pose.id} value={pose.id}>
-              {pose.name}（{pose.description}）
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* ポーズのセレクトボックス（任意） */}
+      <CheerSelectField
+        label="ポーズ（任意）"
+        value={form.poseId}
+        onChange={(val) => handleChange("poseId", val)}
+        options={poses.map((p) => ({
+          value: p.id,
+          label: `${p.name}（${p.description}）`,
+        }))}
+      />
 
-      {/* エラー表示 */}
+      {/* バリデーションエラー表示 */}
       {error && <div className="text-sm text-red-600">{error}</div>}
 
-      {/* 保存ボタン */}
+      {/* フォーム送信ボタン */}
       <Button type="submit" className="w-full rounded-xl text-base py-2">
         保存
       </Button>

--- a/frontend/components/cheer/forms/EditCheerForm.tsx
+++ b/frontend/components/cheer/forms/EditCheerForm.tsx
@@ -8,26 +8,34 @@ import type { CheerFormState } from "@/lib/types/cheer";
 import { useImageUploader } from "@/lib/hooks/useImageUploader";
 
 type Props = {
-  cheerId: number;
-  muscles: Muscle[];
-  poses: Pose[];
-  initialForm: CheerFormState;
-  onSubmit: (form: CheerFormState) => void | Promise<void>;
+  cheerId: number;                                  // 編集対象の掛け声ID（未使用だが保持）
+  muscles: Muscle[];                               // 筋肉部位の選択肢
+  poses: Pose[];                                   // ポーズの選択肢
+  initialForm: CheerFormState;                     // 初期状態のフォームデータ
+  onSubmit: (form: CheerFormState) => void | Promise<void>; // 保存時の処理（親に渡す）
 };
 
+/**
+ * 掛け声を編集するためのフォームコンポーネント
+ */
 export default function EditCheerForm({
   muscles,
   poses,
   initialForm,
   onSubmit,
 }: Props) {
+  // 入力フォームの状態
   const [form, setForm] = useState<CheerFormState>(initialForm);
+
+  // 入力バリデーションエラー用の状態
   const [error, setError] = useState<string | null>(null);
 
+  // 初期データが変わったときに再設定
   useEffect(() => {
     setForm(initialForm);
   }, [initialForm]);
 
+  // 各フィールドの変更ハンドラ
   const handleChange = <K extends keyof CheerFormState>(
     key: K,
     value: CheerFormState[K]
@@ -35,6 +43,7 @@ export default function EditCheerForm({
     setForm((prev) => ({ ...prev, [key]: value }));
   };
 
+  // 画像アップロード用のカスタムフック
   const {
     uploading,
     uploadedUrl,
@@ -44,12 +53,14 @@ export default function EditCheerForm({
     reset,
   } = useImageUploader();
 
+  // アップロード完了後に画像URLをフォームに反映
   useEffect(() => {
     if (uploadedUrl) {
       setForm((prev) => ({ ...prev, imageUrl: uploadedUrl }));
     }
   }, [uploadedUrl]);
 
+  // フォーム送信処理
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!form.text || form.text.length > 50) {
@@ -67,6 +78,7 @@ export default function EditCheerForm({
     >
       <h2 className="text-lg font-bold text-card-foreground">掛け声を編集</h2>
 
+      {/* 掛け声テキスト入力欄 */}
       <div className="space-y-1">
         <label className="block text-sm font-semibold">掛け声テキスト</label>
         <input
@@ -80,6 +92,7 @@ export default function EditCheerForm({
         />
       </div>
 
+      {/* 筋肉部位の選択 */}
       <div className="space-y-1">
         <label className="block text-sm font-semibold">筋肉部位</label>
         <select
@@ -98,6 +111,7 @@ export default function EditCheerForm({
         </select>
       </div>
 
+      {/* ポーズの選択 */}
       <div className="space-y-1">
         <label className="block text-sm font-semibold">ポーズ</label>
         <select
@@ -120,45 +134,46 @@ export default function EditCheerForm({
       <div className="space-y-2">
         <label className="text-sm font-semibold block">画像（任意）</label>
 
-{/* 現在の画像プレビュー */}
-{form.imageUrl && !previewUrl && (
-  <div className="mb-2">
-    {/* eslint-disable-next-line @next/next/no-img-element */}
-    <img
-      src={form.imageUrl}
-      alt="現在の画像"
-      className="rounded-xl border max-h-40 object-contain mx-auto"
-      width={320}
-      height={240}
-    />
-  </div>
-)}
+        {/* 現在の画像プレビュー */}
+        {form.imageUrl && !previewUrl && (
+          <div className="mb-2">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={form.imageUrl}
+              alt="現在の画像"
+              className="rounded-xl border max-h-40 object-contain mx-auto"
+              width={320}
+              height={240}
+            />
+          </div>
+        )}
 
-{/* 新しいプレビュー */}
-{previewUrl && (
-  <div className="mb-2">
-    {/* eslint-disable-next-line @next/next/no-img-element */}
-    <img
-      src={previewUrl}
-      alt="プレビュー画像"
-      className="rounded-xl border max-h-40 object-contain mx-auto"
-      width={320}
-      height={240}
-    />
-    <div className="flex justify-center mt-2">
-      <Button
-        type="button"
-        onClick={reset}
-        variant="outline"
-        size="sm"
-        className="rounded-lg"
-      >
-        画像を変更
-      </Button>
-    </div>
-  </div>
-)}
-        {/* アップロードボタン */}
+        {/* 新しいプレビュー */}
+        {previewUrl && (
+          <div className="mb-2">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={previewUrl}
+              alt="プレビュー画像"
+              className="rounded-xl border max-h-40 object-contain mx-auto"
+              width={320}
+              height={240}
+            />
+            <div className="flex justify-center mt-2">
+              <Button
+                type="button"
+                onClick={reset}
+                variant="outline"
+                size="sm"
+                className="rounded-lg"
+              >
+                画像を変更
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* アップロード用のボタン */}
         <label className="block w-full cursor-pointer rounded-xl border border-dashed border-input bg-white px-4 py-3 text-center text-sm text-muted-foreground hover:bg-gray-50 transition">
           画像を選択
           <input
@@ -170,12 +185,14 @@ export default function EditCheerForm({
           />
         </label>
 
-        {/* エラー表示 */}
+        {/* アップロードエラー表示 */}
         {uploadError && <div className="text-sm text-red-600">{uploadError}</div>}
       </div>
 
+      {/* 入力エラー表示 */}
       {error && <div className="text-destructive text-sm">{error}</div>}
 
+      {/* 送信ボタン */}
       <Button type="submit" className="w-full mt-2">
         保存
       </Button>

--- a/frontend/components/cheer/forms/common/CheerImageUploader.tsx
+++ b/frontend/components/cheer/forms/common/CheerImageUploader.tsx
@@ -1,0 +1,61 @@
+//frontend/components/cheer/forms/common/CheerImageUploader.tsx
+// 画像アップローダー（掛け声用）
+
+import { useImageUploader } from "@/lib/hooks/useImageUploader";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  onUploadComplete: (url: string) => void;
+};
+
+export function CheerImageUploader({ onUploadComplete }: Props) {
+  const {
+    uploading,
+    uploadedUrl,
+    previewUrl,
+    error: uploadError,
+    handleFileChange,
+    reset,
+  } = useImageUploader();
+
+  // アップロード完了時、親にURLを渡す
+  if (uploadedUrl) {
+    onUploadComplete(uploadedUrl);
+  }
+
+  return (
+    <div className='space-y-2'>
+      <label className='text-sm font-medium text-muted-foreground block'>画像ファイル(必須)</label>
+      <label className='block w-full cursor-pointer rounded-xl border border-dashed border-input bg-white px-4 py-3 text-center text-sm text-muted-foreground hover:bg-gray-50 transition'>
+        画像を選択
+        <input type='file' accept='image/*' onChange={handleFileChange} disabled={uploading} className='hidden' />
+      </label>
+
+      {!previewUrl && !uploading && (
+        <p className='text-xs text-muted-foreground text-center'>
+          筋肉やポージングがわかる画像をアップロードしてください
+        </p>
+      )}
+
+      {previewUrl && (
+        <div className='mt-2 space-y-2'>
+          <Image
+            src={previewUrl}
+            alt='画像プレビュー'
+            className='rounded-xl border max-h-40 object-contain mx-auto'
+            width={320}
+            height={240}
+          />
+          <div className='flex justify-center'>
+            <Button type='button' onClick={reset} variant='outline' size='sm' className='rounded-lg'>
+              画像を変更
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {uploadError && <div className='text-sm text-red-600'>{uploadError}</div>}
+    </div>
+  );
+}

--- a/frontend/components/cheer/forms/common/CheerKeywordInput.tsx
+++ b/frontend/components/cheer/forms/common/CheerKeywordInput.tsx
@@ -1,0 +1,60 @@
+//frontend/components/cheer/forms/common/CheerKeywordInput.tsx
+// フリワード入力用
+
+"use client";
+
+import React from "react";
+
+/**
+ * CheerKeywordInput コンポーネントに渡す props の型定義
+ */
+type Props = {
+  /** フィールドのラベルに表示するテキスト（例：フリーワード） */
+  label?: string;
+
+  /** 現在のキーワード入力値（最大50文字） */
+  value: string;
+
+  /** 入力値が変更されたときに呼ばれるコールバック関数 */
+  onChange: (value: string) => void;
+
+  /** プレースホルダーとして表示するテキスト（省略可能） */
+  placeholder?: string;
+};
+
+/**
+ * 掛け声のキーワード入力欄
+ * - 任意入力
+ * - 最大50文字
+ * - フォーム共通化用のシンプルな再利用コンポーネント
+ */
+export function CheerKeywordInput({
+  label = "フリーワード（任意）",
+  value,
+  onChange,
+  placeholder = "例：流行語・アニメ名 など",
+}: Props) {
+  return (
+    <div className="space-y-1">
+      {/* ラベル表示 */}
+      <label className="text-sm font-medium text-muted-foreground">
+        {label}
+      </label>
+
+      {/* テキスト入力フィールド */}
+      <input
+        type="text"
+        maxLength={50}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        placeholder={placeholder}
+      />
+
+      {/* 現在の文字数 */}
+      <p className="text-xs text-muted-foreground text-right">
+        {value.length}/50文字
+      </p>
+    </div>
+  );
+}

--- a/frontend/components/cheer/forms/common/CheerSelectField.tsx
+++ b/frontend/components/cheer/forms/common/CheerSelectField.tsx
@@ -1,0 +1,70 @@
+//frontend/components/cheer/forms/common/CheerSelectField.tsx
+// セレクト共通（タイプ・筋肉・ポーズ）
+
+"use client";
+
+import React from "react";
+
+/**
+ * セレクトボックスの選択肢として使う型
+ * 例：筋肉・ポーズ・タイプ など
+ */
+export type Option = {
+  value: number | "";
+  label: string;
+};
+
+/**
+ * CheerSelectField コンポーネントのProps（引数）
+ */
+type Props = {
+  /** ラベルとして表示するテキスト（例：「筋肉部位」など） */
+  label: string;
+  /** 現在の選択値（id or 空文字） */
+  value: number | "";
+  /** 選択が変わったときに呼ばれる関数 */
+  onChange: (value: number | "") => void;
+  /** 選択肢の一覧（Option型の配列） */
+  options: Option[];
+  /** 未選択時に表示するプレースホルダー（省略可） */
+  placeholder?: string;
+};
+
+/**
+ * 汎用的なセレクトボックス（筋肉・ポーズ・タイプ用）
+ */
+export function CheerSelectField({
+  label,
+  value,
+  onChange,
+  options,
+  placeholder = "選択してください",
+}: Props) {
+  return (
+    <div className='space-y-1'>
+      {/* ラベル表示 */}
+      <label className='text-sm font-medium text-muted-foreground'>
+        {label}
+      </label>
+
+      {/* セレクトボックス本体 */}
+      <select
+        value={value}
+        onChange={(e) =>
+          onChange(e.target.value === "" ? "" : Number(e.target.value))
+        }
+        className='w-full rounded-lg border border-input bg-white px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-ring'
+      >
+        {/* 初期表示用の空オプション */}
+        <option value=''>{placeholder}</option>
+
+        {/* options 配列を使って選択肢を並べる */}
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/components/cheer/forms/common/CheerTextInput.tsx
+++ b/frontend/components/cheer/forms/common/CheerTextInput.tsx
@@ -1,0 +1,64 @@
+//frontend/components/cheer/forms/common/CheerTextInput.tsx
+// フリーワード入力欄
+
+"use client";
+
+import React from "react";
+
+/**
+ * CheerTextInput コンポーネントに渡す props の型定義
+ */
+type Props = {
+  /** フィールドのラベルに表示されるテキスト */
+  label: string;
+
+  /** 現在の入力値（1〜50文字） */
+  value: string;
+
+  /** 値が変更されたときに呼ばれる関数（親から渡される） */
+  onChange: (value: string) => void;
+
+  /** プレースホルダーのテキスト（省略可） */
+  placeholder?: string;
+
+  /** 入力フィールドの必須指定（省略可、デフォルトtrue） */
+  required?: boolean;
+};
+
+/**
+ * 掛け声テキスト用の入力フィールドコンポーネント
+ * - 最大50文字
+ * - バリデーションやラベル表示にも対応
+ */
+export function CheerTextInput({
+  label,
+  value,
+  onChange,
+  placeholder = "例：背中にでっかいジープ乗せてんのかい!!",
+  required = true,
+}: Props) {
+  return (
+    <div className="space-y-1">
+      {/* ラベル（フィールド名） */}
+      <label className="text-sm font-medium text-muted-foreground">
+        {label}
+      </label>
+
+      {/* テキスト入力ボックス */}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={50}
+        required={required}
+        placeholder={placeholder}
+        className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      />
+
+      {/* 補足：文字数上限などのガイドを追加しても良い */}
+      <p className="text-xs text-muted-foreground text-right">
+        {value.length}/50文字
+      </p>
+    </div>
+  );
+}

--- a/frontend/lib/types/cheer.ts
+++ b/frontend/lib/types/cheer.ts
@@ -26,7 +26,6 @@ export type PaginatedCheers = {
 };
 
 
-
 // 保存用フォーム状態
 export type CheerFormState = {
   text: string;
@@ -36,6 +35,14 @@ export type CheerFormState = {
   imageUrl?: string | null;
   keyword?: string | null;
   cheerMode: "manual" | "ai" | "image_ai";
+};
+
+//フォーム内部で扱う状態（選択中の項目やキーワード）
+export type FormState = {
+  cheerTypeId: number | "";  // 選択中の掛け声タイプID（未選択は空文字）
+  muscleId: number | "";     // 選択中の筋肉ID（未選択は空文字）
+  poseId: number | "";       // 選択中のポーズID（未選択は空文字）
+  keyword: string;           // フリーワード入力
 };
 
 // 掛け声AI生成リクエスト（テキスト版）


### PR DESCRIPTION
フォームステートの初期化を useState<CheerFormState> により型明示し、状態管理を明確化

handleChange関数において、key: keyof CheerFormState とすることで対象プロパティの名前を限定し、型安全に更新可能にした

各セクション（テキスト、セレクト、エラー、ボタン）にコメントを追加し、初学者でも理解しやすい構造に整理

Props型の各プロパティに横コメントを追加し、役割を即座に把握できるようにした

全体構造を読みやすい順序（タイトル→入力→選択→エラー→ボタン）に整理

JSX内の各UI要素にもラベルやプレースホルダを丁寧に設定し、UXを改善

