### PR TITLE
画像表示を任意にしてパフォーマンスを向上

### DIFF
--- a/frontend/app/cheers/page.tsx
+++ b/frontend/app/cheers/page.tsx
@@ -4,13 +4,13 @@ import { getCheerPresets } from "@/lib/server/cheerPresets";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import type { Cheer } from "@/lib/types/cheer";
-import CheersList from "@/components/cheer/list/CheersList";
 import CheersFilter from "@/components/cheer/filter/CheersFilter";
 import { AdBanner } from "@/components/ads/AdBanner";
 import { FloatingCreateButton } from "@/components/cheer/ui/FloatingCreateButton";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import Pagination from "@/components/ui/Pagination";
+import CheerDisplayController from "@/components/cheer/list/CheerDisplayController"; // 👈 追加
 
 interface Props {
   searchParams: Promise<Record<string, string | string[]>>;
@@ -18,13 +18,19 @@ interface Props {
 
 export default async function CheersPage({ searchParams }: Props) {
   const { userId } = await auth();
+  //URLのクエリ情報（?以降の部分）が「オブジェクト形式」で取得
   const resolvedSearchParams = await searchParams;
 
+  // 掛け声データの初期化
   let cheers: Cheer[] = [];
   let totalPages = 1;
-
+  // 現在のページ番号をクエリパラメータから取得（指定がなければ1ページ目）
   const page = Number(resolvedSearchParams.page ?? 1);
 
+  // pose（ポーズIDの配列）と muscle（筋肉IDの配列）をクエリから取得し整形する
+  // クエリパラメータはstring(単数)またはstring(複数)の可能性があるので型分岐で対応
+  // --- pose（ポーズID）の取得処理 ---
+  // クエリが string ならそのまま、string[] なら最初の要素だけ、どちらでもない場合は空文字
   const poseParam =
     typeof resolvedSearchParams.pose === "string"
       ? resolvedSearchParams.pose
@@ -37,12 +43,12 @@ export default async function CheersPage({ searchParams }: Props) {
       : Array.isArray(resolvedSearchParams.muscle)
         ? resolvedSearchParams.muscle[0]
         : "";
-
+  // 取得したposeParamとmuscleParamをカンマ区切りで分割 → 数値配列に変換（例："1,2,3" → [1, 2, 3]）
   const poseIds = poseParam ? poseParam.split(",").map(Number) : [];
   const muscleIds = muscleParam ? muscleParam.split(",").map(Number) : [];
-
+  // プリセット（筋肉部位、ポーズ）取得
   const { muscles, poses } = await getCheerPresets();
-
+  // ログインしている場合のみ掛け声を取得
   if (userId) {
     const result = await getCheers({ page, poseIds, muscleIds });
     cheers = result.cheers;
@@ -50,15 +56,17 @@ export default async function CheersPage({ searchParams }: Props) {
   }
 
   return (
-    <div className='max-w-xl mx-auto px-4 py-8 pb-28 relative'>
-      <h1 className='text-xl font-bold text-foreground mb-6 text-center'>
+    <div className="max-w-xl mx-auto px-4 py-8 pb-28 relative">
+      <h1 className="text-xl font-bold text-foreground mb-6 text-center">
         マイ掛け声ライブラリ
       </h1>
 
       {userId ? (
         <>
           <CheersFilter muscles={muscles} poses={poses} />
-          <CheersList
+
+          {/* 👇 画像表示切替機能を含めた一覧ラッパー */}
+          <CheerDisplayController
             cheers={cheers}
             totalPages={totalPages}
             currentPage={page}
@@ -68,15 +76,16 @@ export default async function CheersPage({ searchParams }: Props) {
               redirect("/cheers");
             }}
           />
+
           <Pagination currentPage={page} totalPages={totalPages} />
         </>
       ) : (
-        <div className='text-center text-muted-foreground mt-10 space-y-4'>
+        <div className="text-center text-muted-foreground mt-10 space-y-4">
           <p>掛け声を作成・保存するにはログインが必要です。</p>
-          <Link href='/sign-in'>
+          <Link href="/sign-in">
             <Button
-              variant='default'
-              className='rounded-xl px-5 py-2 text-base'
+              variant="default"
+              className="rounded-xl px-5 py-2 text-base"
             >
               ログインして始める
             </Button>
@@ -84,7 +93,7 @@ export default async function CheersPage({ searchParams }: Props) {
         </div>
       )}
 
-      <div className='mt-6'>
+      <div className="mt-6">
         <AdBanner />
       </div>
 

--- a/frontend/components/cheer/list/CheerCard.tsx
+++ b/frontend/components/cheer/list/CheerCard.tsx
@@ -8,11 +8,12 @@ import type { Cheer } from "@/lib/types/cheer";
 import { useTransition, useState } from "react";
 
 type Props = {
-  cheer: Cheer;
-  onDelete: (id: number) => Promise<void>;
+  cheer: Cheer;                       // 掛け声の情報
+  onDelete: (id: number) => Promise<void>; // 削除ハンドラ
+  showImage: boolean;                 // このカードで画像を表示するかどうか
 };
 
-export function CheerCard({ cheer, onDelete }: Props) {
+export function CheerCard({ cheer, onDelete, showImage }: Props) {
   const [isPending, startTransition] = useTransition();
   const [removing, setRemoving] = useState(false);
 
@@ -27,39 +28,39 @@ export function CheerCard({ cheer, onDelete }: Props) {
   };
 
   return (
-    <div className='border border-border rounded-xl bg-card p-4 shadow-sm space-y-3'>
-      {/* 画像 */}
-      {cheer.image_url && (
-        <div className='w-full aspect-[4/3] relative rounded-md overflow-hidden border'>
+    <div className="border border-border rounded-xl bg-card p-4 shadow-sm space-y-3">
+      {/* 画像表示 */}
+      {showImage && cheer.image_url && (
+        <div className="w-full aspect-[4/3] relative rounded-md overflow-hidden border">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={cheer.image_url}
-            alt='掛け声画像'
-            className='w-full h-full object-contain absolute inset-0'
+            alt="掛け声画像"
+            className="w-full h-full object-contain absolute inset-0"
           />
         </div>
       )}
 
-      {/* テキスト情報 */}
-      <div className='text-card-foreground text-sm space-y-1'>
-        <div className='text-base font-bold'>{cheer.text}</div>
-        <div className='text-muted-foreground'>
+      {/* 掛け声テキストと説明 */}
+      <div className="text-card-foreground text-sm space-y-1">
+        <div className="text-base font-bold">{cheer.text}</div>
+        <div className="text-muted-foreground">
           {cheer.muscle?.name && <span>{cheer.muscle.name}</span>}
           {cheer.pose?.name && <span>・{cheer.pose.name}</span>}
         </div>
       </div>
 
-      {/* ボタン群 */}
-      <div className='flex justify-between gap-2 flex-wrap'>
-        <Link href={`/cheers/${cheer.id}/edit`} className='flex-1 min-w-[90px]'>
-          <Button variant='outline' size='sm' className='w-full'>
+      {/* アクションボタン */}
+      <div className="flex justify-between gap-2 flex-wrap">
+        <Link href={`/cheers/${cheer.id}/edit`} className="flex-1 min-w-[90px]">
+          <Button variant="outline" size="sm" className="w-full">
             編集
           </Button>
         </Link>
 
         <Button
-          size='sm'
-          className='flex-1 min-w-[90px] bg-red-500 text-white hover:bg-red-600'
+          size="sm"
+          className="flex-1 min-w-[90px] bg-red-500 text-white hover:bg-red-600"
           disabled={isPending || removing}
           onClick={handleDelete}
         >
@@ -67,9 +68,9 @@ export function CheerCard({ cheer, onDelete }: Props) {
         </Button>
 
         <Button
-          variant='outline'
-          size='sm'
-          className='flex-1 min-w-[90px] flex items-center justify-center gap-1 border-foreground hover:bg-muted'
+          variant="outline"
+          size="sm"
+          className="flex-1 min-w-[90px] flex items-center justify-center gap-1 border-foreground hover:bg-muted"
           onClick={() =>
             window.open(
               `https://twitter.com/intent/tweet?text=${encodeURIComponent(

--- a/frontend/components/cheer/list/CheerDisplayController.tsx
+++ b/frontend/components/cheer/list/CheerDisplayController.tsx
@@ -1,0 +1,52 @@
+//✅ frontend/components/cheer/list/CheerDisplayController.tsx
+// 掛け声の画像表示=状態を制御するコンポーネント
+
+"use client";
+
+import { useState } from "react";
+import type { Cheer } from "@/lib/types/cheer";
+import CheersList from "./CheersList";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  cheers: Cheer[];                  // 掛け声の一覧
+  totalPages: number;              // 総ページ数（ページネーション用）
+  currentPage: number;            // 現在のページ番号
+  onDelete: (id: number) => Promise<void>; // 掛け声削除ハンドラ
+};
+
+// 掛け声一覧と、画像の一括表示/非表示切り替えを管理するクライアントコンポーネント
+export default function CheerDisplayController({
+  cheers,
+  totalPages,
+  currentPage,
+  onDelete,
+}: Props) {
+  // 画像表示の切り替え状態
+  const [showImages, setShowImages] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      {/* 画像表示切り替えボタン */}
+      <div className="text-right">
+        <Button
+          size="sm"
+          variant="outline"
+          className="text-sm rounded-lg"
+          onClick={() => setShowImages((prev) => !prev)}
+        >
+          {showImages ? "画像を非表示にする" : "画像をすべて表示"}
+        </Button>
+      </div>
+
+      {/* 掛け声一覧 */}
+      <CheersList
+        cheers={cheers}
+        totalPages={totalPages}
+        currentPage={currentPage}
+        onDelete={onDelete}
+        showImages={showImages} // ← ここがポイント
+      />
+    </div>
+  );
+}

--- a/frontend/components/cheer/list/CheersList.tsx
+++ b/frontend/components/cheer/list/CheersList.tsx
@@ -6,31 +6,37 @@ import { CheerCard } from "./CheerCard";
 import Pagination from "@/components/ui/Pagination";
 import CheerEmptyState from "./CheerEmptyState";
 
-
-interface Props {
-  cheers: Cheer[];
-  totalPages: number;
-  currentPage: number;
-  onDelete: (id: number) => Promise<void>;
-}
+type Props = {
+  cheers: Cheer[];                    // 掛け声の配列
+  totalPages: number;                // 総ページ数
+  currentPage: number;              // 現在のページ番号
+  onDelete: (id: number) => Promise<void>; // 削除ハンドラ
+  showImages: boolean;              // 画像を表示するかどうかのフラグ
+};
 
 export default function CheersList({
   cheers,
   totalPages,
   currentPage,
   onDelete,
+  showImages,
 }: Props) {
-  // 掛け声がない場合の案内
-if (cheers.length === 0) {
-  return <CheerEmptyState />;
-}
+  // 掛け声が存在しない場合の表示
+  if (cheers.length === 0) {
+    return <CheerEmptyState />;
+  }
 
   return (
-    <div className='space-y-6'>
+    <div className="space-y-6">
       {/* 掛け声一覧 */}
-      <div className='space-y-4 w-full max-w-lg mx-auto'>
+      <div className="space-y-4 w-full max-w-lg mx-auto">
         {cheers.map((cheer) => (
-          <CheerCard key={cheer.id} cheer={cheer} onDelete={onDelete} />
+          <CheerCard
+            key={cheer.id}
+            cheer={cheer}
+            onDelete={onDelete}
+            showImage={showImages} // ← ここで渡す
+          />
         ))}
       </div>
 


### PR DESCRIPTION
一覧表示（CheerCard）に画像表示を制御する showImages props を追加

一括トグル状態を管理する CheerDisplayController コンポーネントを作成

トグルボタンで showImages を切り替え、CheersList → CheerCard に伝播

ページ遷移・絞り込み・ページネーション時は自動で 非表示 にリセット

画像読み込みを抑えてパフォーマンス改善＋視認性向上を実現