### PR TITLE
掛け声にマイリスト機能を追加

### DIFF
--- a/backend/app/controllers/api/v1/CheerListItemsController.rb
+++ b/backend/app/controllers/api/v1/CheerListItemsController.rb
@@ -1,0 +1,37 @@
+# app/controllers/api/v1/cheer_list_items_controller.rb
+module Api
+  module V1
+    class CheerListItemsController < ApplicationController
+      before_action :set_cheer_my_list
+
+      # GET /api/v1/cheer_my_lists/:cheer_my_list_id/items
+      def index
+        items = @cheer_my_list.cheer_list_items.includes(:cheer).order(:position)
+        render json: items.as_json(include: :cheer)
+      end
+
+      # POST /api/v1/cheer_my_lists/:cheer_my_list_id/items
+      def create
+        item = @cheer_my_list.cheer_list_items.new(cheer_id: params[:cheer_id])
+        if item.save
+          render json: item, status: :created
+        else
+          render json: { error: item.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/cheer_my_lists/:cheer_my_list_id/items/:id
+      def destroy
+        item = @cheer_my_list.cheer_list_items.find(params[:id])
+        item.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_cheer_my_list
+        @cheer_my_list = current_user.cheer_my_lists.find(params[:cheer_my_list_id])
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/cheer_my_lists_controller.rb
+++ b/backend/app/controllers/api/v1/cheer_my_lists_controller.rb
@@ -1,0 +1,46 @@
+# app/controllers/api/v1/cheer_my_lists_controller.rb
+module Api
+  module V1
+    class CheerMyListsController < ApplicationController
+      before_action :set_cheer_my_list, only: [:destroy]
+
+      # GET /api/v1/cheer_my_lists
+      def index
+        lists = current_user.cheer_my_lists.order(created_at: :desc)
+        render json: lists
+      end
+
+      # POST /api/v1/cheer_my_lists
+      def create
+        list = current_user.cheer_my_lists.new(name: params[:name])
+        if list.save
+          render json: list, status: :created
+        else
+          render json: { error: list.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/cheer_my_lists
+      def update
+        list = current_user.cheer_my_lists.find(params[:id])
+        if list.update(name: params[:name])
+          render json: list
+        else
+          render json: { error: "更新失敗" }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/cheer_my_lists/:id
+      def destroy
+        @cheer_my_list.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_cheer_my_list
+        @cheer_my_list = current_user.cheer_my_lists.find(params[:id])
+      end
+    end
+  end
+end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,4 +1,9 @@
 # app/controllers/application_controller.rb
 class ApplicationController < ActionController::API
   include JwtAuthenticatable
+
+  # どこでも current_user が使えるようにする
+  def current_user
+    @current_user
+  end
 end

--- a/backend/app/models/cheer_list_item.rb
+++ b/backend/app/models/cheer_list_item.rb
@@ -1,0 +1,7 @@
+# app/models/cheer_list_item.rb
+class CheerListItem < ApplicationRecord
+  belongs_to :cheer_my_list
+  belongs_to :cheer
+
+  validates :cheer_id, uniqueness: { scope: :cheer_my_list_id }
+end

--- a/backend/app/models/cheer_my_list.rb
+++ b/backend/app/models/cheer_my_list.rb
@@ -1,0 +1,8 @@
+# app/models/cheer_my_list.rb
+class CheerMyList < ApplicationRecord
+  belongs_to :user
+  has_many :cheer_list_items, dependent: :destroy
+  has_many :cheers, through: :cheer_list_items
+
+  validates :name, presence: true
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -2,6 +2,7 @@
 class User < ApplicationRecord
   has_many :cheers, dependent: :destroy
   has_many :ai_generation_limits, dependent: :destroy
+  has_many :cheer_my_lists, dependent: :destroy
 
   validates :clerk_user_id, presence: true, uniqueness: true
   validates :username, presence: true, uniqueness: true

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
       resources :muscles, only: [:index]
       resources :poses, only: [:index]
       post "uploads/presign", to: "uploads#presign" #/api/v1/uploads/presignへのPOSTリクエストをApi::V1::UploadsControllerのpresignアクションにルーティング
+      resources :cheer_my_lists, only: [:index, :create, :update, :destroy] do
+        resources :items, controller: "cheer_list_items", only: [:index, :create, :destroy]
+      end
     end
   end
 end

--- a/backend/db/migrate/20250615113513_create_cheer_my_lists.rb
+++ b/backend/db/migrate/20250615113513_create_cheer_my_lists.rb
@@ -1,0 +1,10 @@
+class CreateCheerMyLists < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cheer_my_lists do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20250615114218_create_cheer_list_items.rb
+++ b/backend/db/migrate/20250615114218_create_cheer_list_items.rb
@@ -1,0 +1,15 @@
+class CreateCheerListItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cheer_list_items do |t|
+      t.references :cheer_my_list, null: false, foreign_key: true
+      t.references :cheer, null: false, foreign_key: true
+
+      t.integer :position
+
+      t.timestamps
+    end
+
+    # 同一リストに同じcheerが複数登録されないようにユニーク制約
+    add_index :cheer_list_items, [:cheer_my_list_id, :cheer_id], unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_15_002454) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_15_114218) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,25 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_15_002454) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "date", "kind"], name: "index_ai_generation_limits_on_user_id_and_date_and_kind", unique: true
     t.index ["user_id"], name: "index_ai_generation_limits_on_user_id"
+  end
+
+  create_table "cheer_list_items", force: :cascade do |t|
+    t.bigint "cheer_my_list_id", null: false
+    t.bigint "cheer_id", null: false
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cheer_id"], name: "index_cheer_list_items_on_cheer_id"
+    t.index ["cheer_my_list_id", "cheer_id"], name: "index_cheer_list_items_on_cheer_my_list_id_and_cheer_id", unique: true
+    t.index ["cheer_my_list_id"], name: "index_cheer_list_items_on_cheer_my_list_id"
+  end
+
+  create_table "cheer_my_lists", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_cheer_my_lists_on_user_id"
   end
 
   create_table "cheer_types", force: :cascade do |t|
@@ -81,6 +100,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_15_002454) do
   end
 
   add_foreign_key "ai_generation_limits", "users"
+  add_foreign_key "cheer_list_items", "cheer_my_lists"
+  add_foreign_key "cheer_list_items", "cheers"
+  add_foreign_key "cheer_my_lists", "users"
   add_foreign_key "cheers", "cheer_types"
   add_foreign_key "cheers", "muscles"
   add_foreign_key "cheers", "poses"

--- a/backend/spec/factories/cheer_list_items.rb
+++ b/backend/spec/factories/cheer_list_items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :cheer_list_item do
+    cheer_my_list { nil }
+    cheer { nil }
+    position { 1 }
+    checked_at { "2025-06-15 11:42:19" }
+  end
+end

--- a/backend/spec/factories/cheer_my_lists.rb
+++ b/backend/spec/factories/cheer_my_lists.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :cheer_my_list do
+    user { nil }
+    name { "MyString" }
+  end
+end

--- a/backend/spec/models/cheer_list_item_spec.rb
+++ b/backend/spec/models/cheer_list_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CheerListItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/cheer_my_list_spec.rb
+++ b/backend/spec/models/cheer_my_list_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CheerMyList, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/frontend/app/cheers/page.tsx
+++ b/frontend/app/cheers/page.tsx
@@ -10,7 +10,7 @@ import { FloatingCreateButton } from "@/components/cheer/ui/FloatingCreateButton
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import Pagination from "@/components/ui/Pagination";
-import CheerDisplayController from "@/components/cheer/list/CheerDisplayController"; // 👈 追加
+import CheerDisplayController from "@/components/cheer/list/CheerDisplayController";
 
 interface Props {
   searchParams: Promise<Record<string, string | string[]>>;
@@ -56,8 +56,8 @@ export default async function CheersPage({ searchParams }: Props) {
   }
 
   return (
-    <div className="max-w-xl mx-auto px-4 py-8 pb-28 relative">
-      <h1 className="text-xl font-bold text-foreground mb-6 text-center">
+    <div className='max-w-xl mx-auto px-4 py-8 pb-28 relative'>
+      <h1 className='text-xl font-bold text-foreground mb-6 text-center'>
         マイ掛け声ライブラリ
       </h1>
 
@@ -65,27 +65,28 @@ export default async function CheersPage({ searchParams }: Props) {
         <>
           <CheersFilter muscles={muscles} poses={poses} />
 
-          {/* 👇 画像表示切替機能を含めた一覧ラッパー */}
-          <CheerDisplayController
-            cheers={cheers}
-            totalPages={totalPages}
-            currentPage={page}
-            onDelete={async (id: number) => {
-              "use server";
-              await deleteCheer(id);
-              redirect("/cheers");
-            }}
-          />
+          <div className="flex justify-center gap-4 mb-4">
+              <CheerDisplayController
+                cheers={cheers}
+                totalPages={totalPages}
+                currentPage={page}
+                onDelete={async (id: number) => {
+                  "use server";
+                  await deleteCheer(id);
+                  redirect("/cheers");
+                }}
+              />
+          </div>
 
           <Pagination currentPage={page} totalPages={totalPages} />
         </>
       ) : (
-        <div className="text-center text-muted-foreground mt-10 space-y-4">
+        <div className='text-center text-muted-foreground mt-10 space-y-4'>
           <p>掛け声を作成・保存するにはログインが必要です。</p>
-          <Link href="/sign-in">
+          <Link href='/sign-in'>
             <Button
-              variant="default"
-              className="rounded-xl px-5 py-2 text-base"
+              variant='default'
+              className='rounded-xl px-5 py-2 text-base'
             >
               ログインして始める
             </Button>
@@ -93,7 +94,7 @@ export default async function CheersPage({ searchParams }: Props) {
         </div>
       )}
 
-      <div className="mt-6">
+      <div className='mt-6'>
         <AdBanner />
       </div>
 

--- a/frontend/app/my-lists/[id]/page.tsx
+++ b/frontend/app/my-lists/[id]/page.tsx
@@ -1,0 +1,64 @@
+// app/my-lists/[id]/page.tsx
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import {
+  getCheersByMyListId,
+  getMyLists,
+  deleteCheerFromMyList,
+} from "@/lib/server/cheers_my_lists";
+import { MyListCheerDisplayController } from "@/components/cheer/mylist/MyListCheerDisplayController";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import type { MyList, MyListCheerItem } from "@/lib/types/cheer";
+
+type Props = {
+  params: {
+    id: string;
+  };
+};
+
+export default async function MyListDetailPage({ params }: Props) {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const listId = Number(params.id);
+
+  // 🔍 自分のマイリスト一覧を取得
+  const myLists: MyList[] = await getMyLists();
+  const targetList = myLists.find((list) => list.id === listId);
+
+  if (!targetList) {
+    return (
+      <div className="max-w-xl mx-auto px-4 py-8 text-center text-muted-foreground">
+        <p>指定されたマイリストは存在しません。</p>
+        <Link href="/my-lists">
+          <Button className="mt-4">マイリスト一覧に戻る</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  // 💬 マイリスト内の掛け声＋itemIdを取得
+  const cheers: MyListCheerItem[] = await getCheersByMyListId(listId);
+
+  return (
+    <div className="max-w-xl mx-auto px-4 py-8 space-y-6">
+      <h1 className="text-xl font-bold text-center">{targetList.name}</h1>
+
+      {cheers.length === 0 ? (
+        <p className="text-center text-muted-foreground">
+          このリストには掛け声が登録されていません。
+        </p>
+      ) : (
+        <MyListCheerDisplayController
+          cheers={cheers}
+          onDelete={async (itemId: number) => {
+            "use server";
+            await deleteCheerFromMyList(listId, itemId);
+            redirect(`/my-lists/${listId}`);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/my-lists/page.tsx
+++ b/frontend/app/my-lists/page.tsx
@@ -1,0 +1,72 @@
+// app/my-lists/page.tsx
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  getMyLists,
+  deleteMyList,
+  createMyList,
+} from "@/lib/server/cheers_my_lists";
+import { MyListCard } from "@/components/cheer/mylist/MyListCard";
+import CreateMyListForm from "@/components/cheer/mylist/CreateMyListForm";
+
+export default async function MyListsPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const myLists = await getMyLists();
+
+  return (
+    <div className='max-w-xl mx-auto px-4 py-8 space-y-6'>
+      <h1 className='text-xl font-bold text-center text-foreground'>
+        マイリスト一覧
+      </h1>
+
+      {myLists.length > 0 ? (
+        <div className='space-y-2'>
+          {myLists.map((list) => (
+            <MyListCard
+              key={list.id}
+              list={list}
+              onDelete={async (id: number) => {
+                "use server";
+                await deleteMyList(id);
+                redirect("/my-lists"); // リスト削除後リロード
+              }}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className='text-center text-muted-foreground space-y-2 text-sm leading-relaxed'>
+          <span className='block'>📁 マイリストはまだ作成されていません。</span>
+          <span className='block'>
+            気に入った掛け声をまとめておくことで、大会や練習前にすぐ見返せます。
+          </span>
+          <span className='block'>
+            下のフォームから、たとえば「大会用」や「元気出したい時用」などのリストを作成してみましょう。
+          </span>
+        </p>
+      )}
+
+      <div>
+        <h2 className='font-semibold mt-6 mb-2'>新しいリストを作成</h2>
+        <CreateMyListForm
+          onCreate={async (name: string) => {
+            "use server";
+            const newList = await createMyList(name);
+            if (newList) redirect(`/my-lists/${newList.id}`);
+          }}
+        />
+      </div>
+
+      <div className='text-center'>
+        <Link href='/cheers'>
+          <Button variant='outline' className='mt-6'>
+            掛け声ライブラリへ戻る
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/cheer/list/CheerCard.tsx
+++ b/frontend/components/cheer/list/CheerCard.tsx
@@ -3,23 +3,24 @@
 
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Share2 } from "lucide-react";
+import { Share2, Plus } from "lucide-react";
 import type { Cheer } from "@/lib/types/cheer";
 import { useTransition, useState } from "react";
+import AddToMyListModal from "@/components/cheer/mylist/AddToMyListModal";
 
 type Props = {
-  cheer: Cheer;                       // 掛け声の情報
+  cheer: Cheer; // 掛け声の情報
   onDelete: (id: number) => Promise<void>; // 削除ハンドラ
-  showImage: boolean;                 // このカードで画像を表示するかどうか
+  showImage: boolean; // このカードで画像を表示するかどうか
 };
 
 export function CheerCard({ cheer, onDelete, showImage }: Props) {
   const [isPending, startTransition] = useTransition();
   const [removing, setRemoving] = useState(false);
+  const [openModal, setOpenModal] = useState(false);
 
   const handleDelete = () => {
     if (!window.confirm("本当に削除しますか？")) return;
-
     setRemoving(true);
     startTransition(async () => {
       await onDelete(cheer.id);
@@ -28,39 +29,39 @@ export function CheerCard({ cheer, onDelete, showImage }: Props) {
   };
 
   return (
-    <div className="border border-border rounded-xl bg-card p-4 shadow-sm space-y-3">
+    <div className='border border-border rounded-xl bg-card p-4 shadow-sm space-y-3'>
       {/* 画像表示 */}
       {showImage && cheer.image_url && (
-        <div className="w-full aspect-[4/3] relative rounded-md overflow-hidden border">
+        <div className='w-full aspect-[4/3] relative rounded-md overflow-hidden border'>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={cheer.image_url}
-            alt="掛け声画像"
-            className="w-full h-full object-contain absolute inset-0"
+            alt='掛け声画像'
+            className='w-full h-full object-contain absolute inset-0'
           />
         </div>
       )}
 
       {/* 掛け声テキストと説明 */}
-      <div className="text-card-foreground text-sm space-y-1">
-        <div className="text-base font-bold">{cheer.text}</div>
-        <div className="text-muted-foreground">
+      <div className='text-card-foreground text-sm space-y-1'>
+        <div className='text-base font-bold'>{cheer.text}</div>
+        <div className='text-muted-foreground'>
           {cheer.muscle?.name && <span>{cheer.muscle.name}</span>}
           {cheer.pose?.name && <span>・{cheer.pose.name}</span>}
         </div>
       </div>
 
       {/* アクションボタン */}
-      <div className="flex justify-between gap-2 flex-wrap">
-        <Link href={`/cheers/${cheer.id}/edit`} className="flex-1 min-w-[90px]">
-          <Button variant="outline" size="sm" className="w-full">
+      <div className='grid grid-cols-2 gap-2 sm:flex sm:justify-between sm:flex-wrap'>
+        <Link href={`/cheers/${cheer.id}/edit`}>
+          <Button variant='outline' size='sm' className='w-full min-w-[90px]'>
             編集
           </Button>
         </Link>
 
         <Button
-          size="sm"
-          className="flex-1 min-w-[90px] bg-red-500 text-white hover:bg-red-600"
+          size='sm'
+          className='w-full min-w-[90px] bg-red-500 text-white hover:bg-red-600'
           disabled={isPending || removing}
           onClick={handleDelete}
         >
@@ -68,9 +69,9 @@ export function CheerCard({ cheer, onDelete, showImage }: Props) {
         </Button>
 
         <Button
-          variant="outline"
-          size="sm"
-          className="flex-1 min-w-[90px] flex items-center justify-center gap-1 border-foreground hover:bg-muted"
+          variant='outline'
+          size='sm'
+            className="w-full min-w-[90px] flex items-center justify-center gap-1 hover:bg-muted"
           onClick={() =>
             window.open(
               `https://twitter.com/intent/tweet?text=${encodeURIComponent(
@@ -83,7 +84,24 @@ export function CheerCard({ cheer, onDelete, showImage }: Props) {
           <Share2 size={16} />
           シェア
         </Button>
+
+        <Button
+          variant='secondary'
+          size='sm'
+          className='w-full min-w-[90px] flex items-center justify-center gap-1 border border-gray-300'
+          onClick={() => setOpenModal(true)}
+        >
+          <Plus size={16} />
+          マイリスト
+        </Button>
       </div>
+
+      {/* モーダル表示 */}
+      <AddToMyListModal
+        cheerId={cheer.id}
+        open={openModal}
+        onOpenChange={setOpenModal}
+      />
     </div>
   );
 }

--- a/frontend/components/cheer/list/CheerDisplayController.tsx
+++ b/frontend/components/cheer/list/CheerDisplayController.tsx
@@ -1,12 +1,13 @@
-//✅ frontend/components/cheer/list/CheerDisplayController.tsx
-// 掛け声の画像表示=状態を制御するコンポーネント
+//frontend/components/cheer/list/CheerDisplayController.tsx
+// 掛け声の画像表示=状態とマイリスト一覧モーダルの開閉を制御するコンポーネント
 
 "use client";
 
-import { useState } from "react";
+import { useState, } from "react";
 import type { Cheer } from "@/lib/types/cheer";
 import CheersList from "./CheersList";
 import { Button } from "@/components/ui/button";
+import NavigateMyListModal from "@/components/cheer/mylist/NavigateMyListModal";
 
 type Props = {
   cheers: Cheer[];                  // 掛け声の一覧
@@ -15,20 +16,30 @@ type Props = {
   onDelete: (id: number) => Promise<void>; // 掛け声削除ハンドラ
 };
 
-// 掛け声一覧と、画像の一括表示/非表示切り替えを管理するクライアントコンポーネント
 export default function CheerDisplayController({
   cheers,
   totalPages,
   currentPage,
   onDelete,
 }: Props) {
-  // 画像表示の切り替え状態
+  //画像一括表示ボタンの開閉
   const [showImages, setShowImages] = useState(false);
+  //マイリスト一覧もーだるの開閉
+  const [modalOpen, setModalOpen] = useState(false);
 
   return (
     <div className="space-y-4">
-      {/* 画像表示切り替えボタン */}
-      <div className="text-right">
+      {/* 操作ボタン：中央寄せ＋並列表示（スマホ対応） */}
+      <div className="flex justify-center items-center gap-3 flex-wrap">
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-sm"
+          onClick={() => setModalOpen(true)}
+        >
+          マイリスト一覧
+        </Button>
+
         <Button
           size="sm"
           variant="outline"
@@ -39,13 +50,16 @@ export default function CheerDisplayController({
         </Button>
       </div>
 
+      {/* モーダル本体（選択で遷移） */}
+      <NavigateMyListModal open={modalOpen} onOpenChange={setModalOpen} />
+
       {/* 掛け声一覧 */}
       <CheersList
         cheers={cheers}
         totalPages={totalPages}
         currentPage={currentPage}
         onDelete={onDelete}
-        showImages={showImages} // ← ここがポイント
+        showImages={showImages}
       />
     </div>
   );

--- a/frontend/components/cheer/list/CheersList.tsx
+++ b/frontend/components/cheer/list/CheersList.tsx
@@ -35,7 +35,7 @@ export default function CheersList({
             key={cheer.id}
             cheer={cheer}
             onDelete={onDelete}
-            showImage={showImages} // ← ここで渡す
+            showImage={showImages}
           />
         ))}
       </div>

--- a/frontend/components/cheer/mylist/AddToMyListModal.tsx
+++ b/frontend/components/cheer/mylist/AddToMyListModal.tsx
@@ -1,0 +1,111 @@
+//frontend/components/cheer/mylist/AddToMyListModal.tsx
+//マイリストを選択して掛け声を追加できる、その場で新しいマイリストも作成可能
+
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useMyLists } from "@/lib/hooks/useMyLists";
+
+type Props = {
+  cheerId: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function AddToMyListModal({ cheerId, open, onOpenChange }: Props) {
+  const {
+    myLists,
+    error,
+    fetchMyLists,
+    createMyList,
+    addCheerToList,
+  } = useMyLists();
+
+  const [newListName, setNewListName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // モーダル表示時にマイリスト一覧を取得
+  useEffect(() => {
+    if (open) {
+      fetchMyLists();
+    }
+  }, [open, fetchMyLists]);
+
+  const handleAddToExistingList = async (listId: number) => {
+    setIsSubmitting(true);
+    const success = await addCheerToList(listId, cheerId);
+    if (success) onOpenChange(false);
+    setIsSubmitting(false);
+  };
+
+  const handleCreateListAndAdd = async () => {
+    if (!newListName.trim()) return;
+    setIsSubmitting(true);
+    const newList = await createMyList(newListName.trim());
+    if (newList) {
+      await addCheerToList(newList.id, cheerId);
+      onOpenChange(false);
+    }
+    setIsSubmitting(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>マイリストに追加</DialogTitle>
+          <DialogDescription>
+            掛け声を保存するリストを選ぶか、新しく作成してください。
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* 既存のリストから選ぶ */}
+        <div className="space-y-2">
+          {myLists.length > 0 ? (
+            myLists.map((list) => (
+              <Button
+                key={list.id}
+                variant="outline"
+                className="w-full justify-start"
+                disabled={isSubmitting}
+                onClick={() => handleAddToExistingList(list.id)}
+              >
+                {list.name}
+              </Button>
+            ))
+          ) : (
+            <p className="text-muted-foreground text-sm">マイリストが見つかりません</p>
+          )}
+        </div>
+
+        {/* 新しく作る */}
+        <div className="mt-4 space-y-2">
+          <Input
+            placeholder="新しいリスト名を入力"
+            value={newListName}
+            onChange={(e) => setNewListName(e.target.value)}
+            disabled={isSubmitting}
+          />
+          <Button
+            onClick={handleCreateListAndAdd}
+            className="w-full"
+            disabled={isSubmitting}
+          >
+            作成して追加
+          </Button>
+        </div>
+
+        {error && <p className="text-sm text-red-500 mt-2">{error}</p>}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/cheer/mylist/CreateMyListForm.tsx
+++ b/frontend/components/cheer/mylist/CreateMyListForm.tsx
@@ -1,0 +1,43 @@
+//frontend/components/cheer/mylist/CreateMyListForm.tsx
+// 新規マイリスト作成フォーム
+"use client";
+
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  onCreate: (name: string) => Promise<void>;
+  disabled?: boolean;
+};
+
+export default function CreateMyListForm({ onCreate, disabled }: Props) {
+  const [name, setName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!name.trim()) return;
+    setIsSubmitting(true);
+    await onCreate(name.trim());
+    setIsSubmitting(false);
+    setName(""); // 入力欄をリセット
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        placeholder="新しいリスト名を入力"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        disabled={isSubmitting || disabled}
+      />
+      <Button
+        onClick={handleSubmit}
+        className="w-full"
+        disabled={isSubmitting || disabled}
+      >
+        {isSubmitting ? "作成中..." : "作成して追加"}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/components/cheer/mylist/MyListCard.tsx
+++ b/frontend/components/cheer/mylist/MyListCard.tsx
@@ -1,0 +1,102 @@
+// frontend/components/cheer/mylist/MyListCard.tsx
+//マイリストのカードコンポーネント
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import type { MyList } from "@/lib/types/cheer";
+import { Pencil, Trash2, Check, X } from "lucide-react";
+import { useMyListUpdater } from "@/lib/hooks/useMyListUpdater";
+
+type Props = {
+  list: MyList;
+  onDelete: (id: number) => void;
+};
+
+export function MyListCard({ list, onDelete }: Props) {
+  const router = useRouter();
+  const { updateMyListName } = useMyListUpdater();
+
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(list.name);
+  const [loading, setLoading] = useState(false);
+
+  const handleUpdate = async () => {
+    if (name.trim() === "" || name === list.name) {
+      setEditing(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      await updateMyListName(list.id, name);
+      router.refresh(); // マイリスト一覧の再取得
+    } catch (e) {
+      console.error("マイリスト更新エラー:", e);
+      alert("更新に失敗しました");
+    } finally {
+      setEditing(false);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className='flex items-center justify-between border p-4 rounded-xl shadow-sm bg-white'>
+      <div className='flex-1'>
+        {editing ? (
+          <div className='flex items-center gap-2'>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className='border rounded px-2 py-1 text-sm w-full'
+              autoFocus
+            />
+            <button onClick={handleUpdate} disabled={loading}>
+              <Check className='text-green-600' size={18} />
+            </button>
+            <button
+              onClick={() => {
+                setName(list.name);
+                setEditing(false);
+              }}
+            >
+              <X className='text-gray-500' size={18} />
+            </button>
+          </div>
+        ) : (
+          <div
+            className='cursor-pointer'
+            onClick={() => router.push(`/my-lists/${list.id}`)}
+          >
+            <h3 className='text-base font-semibold text-foreground'>
+              {list.name}
+            </h3>
+          </div>
+        )}
+      </div>
+
+      {!editing && (
+        <div className='flex gap-2'>
+          <Button
+            variant='outline'
+            size='icon'
+            onClick={() => setEditing(true)}
+          >
+            <Pencil size={16} />
+          </Button>
+          <Button
+            size='icon'
+            className='bg-red-600 hover:bg-red-700 text-white rounded-full'
+            onClick={() => {
+              if (confirm(`「${list.name}」を削除しますか？`)) {
+                onDelete(list.id);
+              }
+            }}
+          >
+            <Trash2 size={16} />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/cheer/mylist/MyListCheerCard.tsx
+++ b/frontend/components/cheer/mylist/MyListCheerCard.tsx
@@ -1,0 +1,79 @@
+// frontend/components/cheer/mylist/MyListCheerCard.tsx
+// マイリスト内の掛け声カードコンポーネント
+"use client";
+
+import type { MyListCheerItem } from "@/lib/types/cheer";
+import { Button } from "@/components/ui/button";
+import { Share2 } from "lucide-react";
+import { useState, useTransition } from "react";
+
+type Props = {
+  cheer: MyListCheerItem;
+  onDelete: (itemId: number) => Promise<void>;
+  showImage?: boolean;
+};
+
+export function MyListCheerCard({ cheer, onDelete, showImage = true }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [removing, setRemoving] = useState(false);
+
+  const handleDelete = () => {
+    if (!window.confirm("このリストから削除しますか？")) return;
+    setRemoving(true);
+    startTransition(async () => {
+      await onDelete(cheer.itemId);
+      setRemoving(false);
+    });
+  };
+
+  return (
+    <div className="border border-border rounded-xl bg-card p-4 shadow-sm space-y-3">
+      {/* 画像表示 */}
+      {showImage && cheer.image_url && (
+        <div className="w-full aspect-[4/3] relative rounded-md overflow-hidden border">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={cheer.image_url}
+            alt="掛け声画像"
+            className="w-full h-full object-contain absolute inset-0"
+          />
+        </div>
+      )}
+
+      {/* 掛け声テキストと説明 */}
+      <div className="text-card-foreground space-y-1">
+        <div className="text-lg font-bold tracking-tight leading-snug">
+          {cheer.text}
+        </div>
+      </div>
+
+      {/* アクションボタン */}
+      <div className="flex justify-between gap-2 flex-wrap">
+        <Button
+          size="sm"
+          className="flex-1 min-w-[90px] bg-red-500 text-white hover:bg-red-600"
+          disabled={isPending || removing}
+          onClick={handleDelete}
+        >
+          {isPending || removing ? "削除中..." : "削除"}
+        </Button>
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex-1 min-w-[90px] flex items-center justify-center gap-1 border-foreground hover:bg-muted"
+          onClick={() =>
+            window.open(
+              `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+                `「${cheer.text}」 #ムキメンタリー`
+              )}`,
+              "_blank"
+            )
+          }
+        >
+          <Share2 size={16} /> シェア
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/cheer/mylist/MyListCheerDisplayController.tsx
+++ b/frontend/components/cheer/mylist/MyListCheerDisplayController.tsx
@@ -1,0 +1,46 @@
+// MyListCheerDisplayController.tsx
+//マイリストの掛け声の一覧の画像表示をコントロールする
+
+"use client";
+
+import { useState } from "react";
+import type { MyListCheerItem } from "@/lib/types/cheer";
+import MyListCheersList from "./MyListCheersList";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+interface Props {
+  cheers: MyListCheerItem[];
+  onDelete: (itemId: number) => Promise<void>;
+}
+
+export function MyListCheerDisplayController({ cheers, onDelete }: Props) {
+  const [showImages, setShowImages] = useState(true);
+
+  return (
+    <div className="space-y-4">
+      {/* 操作ボタンを横並びで中央寄せ */}
+      <div className="flex justify-center items-center gap-3 flex-wrap">
+        <Link href="/my-lists">
+          <Button variant="outline" size="sm" className="text-sm">
+            マイリスト一覧に戻る
+          </Button>
+        </Link>
+        <Button
+          size="sm"
+          variant="outline"
+          className="text-sm rounded-lg"
+          onClick={() => setShowImages((prev) => !prev)}
+        >
+          {showImages ? "画像を非表示にする" : "画像をすべて表示"}
+        </Button>
+      </div>
+
+      <MyListCheersList
+        cheers={cheers}
+        onDelete={onDelete}
+        showImages={showImages}
+      />
+    </div>
+  );
+}

--- a/frontend/components/cheer/mylist/MyListCheersList.tsx
+++ b/frontend/components/cheer/mylist/MyListCheersList.tsx
@@ -1,0 +1,42 @@
+// MyListCheersList.tsx
+//マイリスト内の掛け声があれば表示、なければ別の案内が入る
+"use client";
+
+import type { MyListCheerItem } from "@/lib/types/cheer";
+import { MyListCheerCard } from "./MyListCheerCard";
+
+interface Props {
+  cheers: MyListCheerItem[];
+  onDelete: (itemId: number) => Promise<void>;
+  showImages: boolean;
+}
+
+export default function MyListCheersList({ cheers, onDelete, showImages }: Props) {
+  if (cheers.length === 0)
+  return (
+    <div className="text-center text-muted-foreground space-y-4 text-sm max-w-md mx-auto py-10">
+      <p className="text-base font-semibold text-foreground">このマイリストはまだ空です</p>
+      <p>
+        お気に入りの掛け声をこのリストに保存できます。<br />
+        「マイリスト」ボタンから追加して、⼤会や発表の前に見返すことができます。
+      </p>
+      <p>
+        掛け声一覧ページに戻って、お気に入りを追加してみましょう！
+      </p>
+    </div>
+  );
+
+
+  return (
+    <div className="space-y-4">
+      {cheers.map((cheer) => (
+        <MyListCheerCard
+          key={cheer.itemId}
+          cheer={cheer}
+          onDelete={onDelete}
+          showImage={showImages}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/cheer/mylist/NavigateMyListModal.tsx
+++ b/frontend/components/cheer/mylist/NavigateMyListModal.tsx
@@ -1,0 +1,57 @@
+// components/cheer/mylist/NavigateMyListModal.tsx
+// マイリストを選択して遷移するモーダルコンポーネント
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useMyLists } from "@/lib/hooks/useMyLists";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function NavigateMyListModal({ open, onOpenChange }: Props) {
+  const { myLists, fetchMyLists } = useMyLists();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (open) fetchMyLists();
+  }, [open, fetchMyLists]);
+
+  const handleSelect = (listId: number) => {
+    onOpenChange(false);
+    router.push(`/my-lists/${listId}`);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>マイリストを選択</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-2 mt-2">
+          {myLists.length > 0 ? (
+            myLists.map((list) => (
+              <Button
+                key={list.id}
+                variant="outline"
+                className="w-full justify-start"
+                onClick={() => handleSelect(list.id)}
+              >
+                {list.name}
+              </Button>
+            ))
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              マイリストが見つかりません
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/frontend/lib/hooks/useMyListUpdater.ts
+++ b/frontend/lib/hooks/useMyListUpdater.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthFetch } from "@/lib/hooks/useAuthFetch";
+import { getBaseUrl } from "@/lib/utils/getBaseUrl";
+
+export function useMyListUpdater() {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const { fetchWithAuth } = useAuthFetch();
+
+  const updateMyListName = async (id: number, name: string) => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth(`${getBaseUrl()}/api/v1/cheer_my_lists/${id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name }),
+      });
+
+      if (!res.ok) throw new Error("更新失敗");
+
+      router.refresh(); // 一覧を再取得
+    } catch  {
+      alert("マイリスト名の更新に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { updateMyListName, loading };
+}

--- a/frontend/lib/hooks/useMyLists.tsx
+++ b/frontend/lib/hooks/useMyLists.tsx
@@ -1,0 +1,80 @@
+// lib/hooks/useMyLists.ts
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { MyList } from "@/lib/types/cheer";
+import { useAuthFetch } from "@/lib/hooks/useAuthFetch";
+import { getBaseUrl } from "@/lib/utils/getBaseUrl";
+
+export function useMyLists() {
+  const [myLists, setMyLists] = useState<MyList[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { fetchWithAuth } = useAuthFetch();
+  const API_BASE = getBaseUrl();
+
+  // 自分のマイリストを取得
+  const fetchMyLists = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth(`${API_BASE}/api/v1/cheer_my_lists`);
+      if (!res.ok) throw new Error("マイリストの取得に失敗しました");
+      const data = await res.json();
+      setMyLists(data);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchWithAuth, API_BASE]);
+
+  // マイリストを新規作成
+  const createMyList = useCallback(async (name: string): Promise<MyList | null> => {
+    try {
+      const res = await fetchWithAuth(`${API_BASE}/api/v1/cheer_my_lists`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) throw new Error("マイリストの作成に失敗しました");
+      const newList: MyList = await res.json();
+      setMyLists((prev) => [...prev, newList]);
+      return newList;
+    } catch (e) {
+      setError((e as Error).message);
+      return null;
+    }
+  }, [fetchWithAuth, API_BASE]);
+
+  // 指定マイリストにCheerを追加
+  const addCheerToList = useCallback(async (listId: number, cheerId: number): Promise<boolean> => {
+    try {
+      const res = await fetchWithAuth(`${API_BASE}/api/v1/cheer_my_lists/${listId}/items`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cheer_id: cheerId }),
+      });
+      if (!res.ok) throw new Error("マイリストへの追加に失敗しました");
+      return true;
+    } catch (e) {
+      setError((e as Error).message);
+      return false;
+    }
+  }, [fetchWithAuth, API_BASE]);
+
+  // 初回読み込み
+  useEffect(() => {
+    fetchMyLists();
+  }, [fetchMyLists]);
+
+  return {
+    myLists,
+    loading,
+    error,
+    fetchMyLists,
+    createMyList,
+    addCheerToList,
+  };
+}

--- a/frontend/lib/server/cheers.ts
+++ b/frontend/lib/server/cheers.ts
@@ -4,7 +4,7 @@ import { PaginatedCheers, CheerFormState } from "@/lib/types/cheer";
 import { fetchWithAuthServer } from "@/lib/server/fetchWithAuthServer";
 import { getBaseUrl } from "@/lib/utils/getBaseUrl";
 
-// 一覧取得（SSR/Server Action用）
+// 全体またはフィルター付きの「自分の掛け声一覧」を取得（SSR/Server Action用）
 export async function getCheers({
   page = 1,
   poseIds = [],
@@ -102,3 +102,5 @@ export async function deleteCheer(id: number) {
   }
   return true;
 }
+
+

--- a/frontend/lib/server/cheers_my_lists.ts
+++ b/frontend/lib/server/cheers_my_lists.ts
@@ -1,0 +1,132 @@
+//frontend/lib/server/cheers_my_lists.ts
+import "server-only";
+import { fetchWithAuthServer } from "@/lib/server/fetchWithAuthServer";
+import { getBaseUrl } from "@/lib/utils/getBaseUrl";
+import type { Cheer,MyList,MyListCheerItem } from "@/lib/types/cheer";
+
+type CheerListItem = {
+  id: number;
+  cheer_id: number;
+  position: number;
+  cheer: Cheer;
+};
+
+// 自分のマイリスト一覧を取得
+export async function getMyLists(): Promise<MyList[]> {
+  const API_BASE = getBaseUrl();
+  const res = await fetchWithAuthServer(`${API_BASE}/api/v1/cheer_my_lists`);
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    console.error("マイリスト一覧取得失敗:", errorText);
+    throw new Error("マイリスト一覧の取得に失敗しました");
+  }
+
+  return res.json();
+}
+
+// マイリストを新規作成する
+export async function createMyList(name: string): Promise<MyList> {
+  const API_BASE = getBaseUrl();
+
+  const res = await fetchWithAuthServer(
+    `${API_BASE}/api/v1/cheer_my_lists`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error("マイリスト作成失敗:", text);
+    throw new Error("マイリストの作成に失敗しました");
+  }
+
+  const data = await res.json();
+  return data as MyList;
+}
+
+// マイリスト名を更新する関数はserver側では読み込めないので削除
+// export async function updateMyListName(id: number, name: string): Promise<MyList> {
+//   const API_BASE = getBaseUrl();
+
+//   const res = await fetchWithAuthServer(
+//     `${API_BASE}/api/v1/cheer_my_lists/${id}`,
+//     {
+//       method: "PATCH",
+//       headers: { "Content-Type": "application/json" },
+//       body: JSON.stringify({ name }),
+//     }
+//   );
+
+//   if (!res.ok) {
+//     const text = await res.text();
+//     console.error("マイリスト名の更新失敗:", text);
+//     throw new Error("マイリスト名の更新に失敗しました");
+//   }
+
+//   return await res.json();
+// }
+
+// マイリストを削除する
+export async function deleteMyList(id: number) {
+  const API_BASE = getBaseUrl();
+
+  const res = await fetchWithAuthServer(
+    `${API_BASE}/api/v1/cheer_my_lists/${id}`,
+    {
+      method: "DELETE",
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error("マイリスト削除失敗:", text);
+    throw new Error("マイリストの削除に失敗しました");
+  }
+
+  return true;
+}
+
+
+//特定のマイリストIDに紐づく掛け声一覧を取得
+export async function getCheersByMyListId(listId: number): Promise<MyListCheerItem[]> {
+  const API_BASE = getBaseUrl();
+  const res = await fetchWithAuthServer(
+    `${API_BASE}/api/v1/cheer_my_lists/${listId}/items`
+  );
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    console.error("マイリスト内掛け声取得失敗:", errorText);
+    throw new Error("マイリスト内の掛け声取得に失敗しました");
+  }
+
+  const items: CheerListItem[] = await res.json();
+  return items.map((item) => ({
+    ...item.cheer,
+    itemId: item.id, // 👈 ここで cheer_list_items.id を埋め込む
+  }));
+}
+
+// マイリストから1件削除
+export async function deleteCheerFromMyList(listId: number, cheerId: number) {
+  const API_BASE = getBaseUrl();
+
+  const res = await fetchWithAuthServer(
+    `${API_BASE}/api/v1/cheer_my_lists/${listId}/items/${cheerId}`,
+    {
+      method: "DELETE",
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error("マイリスト削除失敗:", text);
+    throw new Error("マイリストからの削除に失敗しました");
+  }
+
+  return true;
+}

--- a/frontend/lib/types/cheer.ts
+++ b/frontend/lib/types/cheer.ts
@@ -68,3 +68,17 @@ export type CheerGenerateResponse = {
   error?: string; // エラー発生時のみ
 };
 
+// 掛け声マイリスト系
+//マイリストの型
+export type MyList = {
+  id: number;
+  name: string;
+  user_id: number;
+  created_at: string;
+  updated_at: string;
+};
+
+// マイリスト内の掛け声アイテムの型
+export type MyListCheerItem = Cheer & {
+  itemId: number; // cheer_list_items.id に相当
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@clerk/localizations": "^3.16.4",
         "@clerk/nextjs": "^6.21.0",
         "@radix-ui/react-checkbox": "^1.3.2",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1446,6 +1447,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@clerk/localizations": "^3.16.4",
     "@clerk/nextjs": "^6.21.0",
     "@radix-ui/react-checkbox": "^1.3.2",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",


### PR DESCRIPTION
マイリスト一覧ページ（/my-lists）を作成し、作成・削除・編集の基本操作を実装。

マイリスト名のインライン編集機能をクライアントフックuseMyListUpdaterで実装。

リスト削除処理はServer Actionとして定義し、ページ内で即時反映されるようリダイレクト制御。

新規作成フォームでは名前入力後に自動で詳細ページへ遷移。

マイリスト詳細ページ（/my-lists/[id]）において、掛け声アイテムの一覧表示・削除・画像表示切り替えに対応。

掛け声カードに「編集・削除・シェア・マイリスト追加」などのアクションボタンを実装し、モバイル表示にも最適化。

モバイル対応レイアウトとして、ボタンの改行・並び・レスポンシブ対応を調整（2列表示など）。

「マイリスト一覧に戻る」ボタンをMyListCheerDisplayControllerに追加し、画像切替ボタンと並列に配置。

空状態時（アイテム0件）の説明UIを追加し、機能の意図が初見でも伝わるように改善。

NavigateMyListModalにリスト選択UIを統合し、MyListSelector.tsxは削除してコードを簡素化。

掛け声カードのシェアボタンの枠線色を調整し、全体の視認性とデザインの統一感を向上。