### PR TITLE
シェア機能の充実

### DIFF
--- a/frontend/app/cheers/create/page.tsx
+++ b/frontend/app/cheers/create/page.tsx
@@ -1,4 +1,5 @@
 // frontend/app/cheers/create/page.tsx
+import { getCheerSamples } from "@/lib/server/cheers";
 import { getCheerPresets } from "@/lib/server/cheerPresets";
 import { createCheer } from "@/lib/server/cheers";
 import CheerTabs from "@/components/cheer/list/CheerTabs";
@@ -8,6 +9,7 @@ import { AdBanner } from "@/components/ads/AdBanner";
 
 export default async function CreateCheerPage() {
   const { cheerTypes, muscles, poses } = await getCheerPresets();
+  const cheerSamples = await getCheerSamples();
 
   async function handleSubmit(form: CheerFormState) {
     "use server";
@@ -25,6 +27,7 @@ export default async function CreateCheerPage() {
         muscles={muscles}
         poses={poses}
         onSubmit={handleSubmit}
+        cheerSamples={cheerSamples}
       />
       <AdBanner />
     </div>

--- a/frontend/components/cheer/forms/CheerAiForm.tsx
+++ b/frontend/components/cheer/forms/CheerAiForm.tsx
@@ -4,7 +4,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { CheerType, Muscle, Pose } from "@/lib/types/prests";
-import type { CheerFormState,FormState } from "@/lib/types/cheer";
+import type { CheerFormState,FormState,Cheer } from "@/lib/types/cheer";
 import { useCheerApi } from "@/lib/hooks/useCheerApi";
 import { GenerateCountInfo } from "@/components/cheer/ui/GenerateCountInfo";
 import { CheerSelectField } from "@/components/cheer/forms/common/CheerSelectField";
@@ -16,6 +16,7 @@ type Props = {
   muscles: Muscle[];                           // 筋肉部位の選択肢
   poses: Pose[];                               // ポーズの選択肢
   onSubmit: (form: CheerFormState) => void | Promise<void>; // フォーム送信時の処理
+  cheerSamples: Cheer[]                         //シェアボーナスで取得用の掛け声一覧
   remaining: number | null;                    // 残り生成回数（nullの場合は未取得）
   onChangeRemaining: (value: number | null) => void; // 残り使用回数の更新用コールバック
 };
@@ -26,6 +27,7 @@ export default function CheerAiForm({
   muscles,
   poses,
   onSubmit,
+  cheerSamples,
   remaining,
   onChangeRemaining,
 }: Props) {
@@ -103,7 +105,7 @@ export default function CheerAiForm({
         テキストとキーワードからAIで掛け声を生成
       </h2>
 
-      <GenerateCountInfo kind="text_ai" onChangeRemaining={onChangeRemaining} />
+      <GenerateCountInfo kind="text_ai" onChangeRemaining={onChangeRemaining} cheerSamples={cheerSamples}/>
 
       {/* 選択フィールド */}
       <CheerSelectField

--- a/frontend/components/cheer/forms/CheerImageAiForm.tsx
+++ b/frontend/components/cheer/forms/CheerImageAiForm.tsx
@@ -4,7 +4,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { CheerType, Muscle, Pose } from "@/lib/types/prests";
-import type { CheerFormState,FormState } from "@/lib/types/cheer";
+import type { CheerFormState,FormState,Cheer } from "@/lib/types/cheer";
 import { useCheerApi } from "@/lib/hooks/useCheerApi";
 import { GenerateCountInfo } from "@/components/cheer/ui/GenerateCountInfo";
 import { CheerSelectField } from "@/components/cheer/forms/common/CheerSelectField";
@@ -17,6 +17,7 @@ type Props = {
   muscles: Muscle[];                           // 筋肉部位の選択肢（セレクト用）
   poses: Pose[];                               // ポーズの選択肢（セレクト用）
   onSubmit: (form: CheerFormState) => void | Promise<void>; // 掛け声データの保存処理（親から受け取る）
+  cheerSamples:Cheer[];                       // シェアボーナスで取得用の掛け声一覧
   remaining: number | null;                    // 残りの生成可能回数（null = 未取得）
   onChangeRemaining: (value: number | null) => void; // 残り回数を更新するための関数
 };
@@ -27,6 +28,7 @@ export default function CheerImageAiForm({
   muscles,
   poses,
   onSubmit,
+  cheerSamples,
   remaining,
   onChangeRemaining,
 }: Props) {
@@ -116,7 +118,7 @@ export default function CheerImageAiForm({
       </h2>
 
       {/* 残り生成回数の表示 */}
-      <GenerateCountInfo kind="image_ai" onChangeRemaining={onChangeRemaining} />
+      <GenerateCountInfo kind="image_ai" onChangeRemaining={onChangeRemaining} cheerSamples={cheerSamples}/>
 
       {/* 画像アップロード */}
       <CheerImageUploader onUploadComplete={(url) => setImageUrl(url)} />

--- a/frontend/components/cheer/list/CheerCard.tsx
+++ b/frontend/components/cheer/list/CheerCard.tsx
@@ -3,10 +3,11 @@
 
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Share2, Plus } from "lucide-react";
+import { Plus, Share2 } from "lucide-react";
 import type { Cheer } from "@/lib/types/cheer";
 import { useTransition, useState } from "react";
 import AddToMyListModal from "@/components/cheer/mylist/AddToMyListModal";
+import ShareModal from "../ui/ShareModal";
 
 type Props = {
   cheer: Cheer; // 掛け声の情報
@@ -18,6 +19,7 @@ export function CheerCard({ cheer, onDelete, showImage }: Props) {
   const [isPending, startTransition] = useTransition();
   const [removing, setRemoving] = useState(false);
   const [openModal, setOpenModal] = useState(false);
+  const [shareOpenModal, setShareOpenModal] = useState(false);
 
   const handleDelete = () => {
     if (!window.confirm("本当に削除しますか？")) return;
@@ -29,39 +31,43 @@ export function CheerCard({ cheer, onDelete, showImage }: Props) {
   };
 
   return (
-    <div className='border border-border rounded-xl bg-card p-4 shadow-sm space-y-3'>
+    <div className="border border-border rounded-xl bg-card p-4 shadow-sm space-y-3">
       {/* 画像表示 */}
       {showImage && cheer.image_url && (
-        <div className='w-full aspect-[4/3] relative rounded-md overflow-hidden border'>
+        <div className="w-full aspect-[4/3] relative rounded-md overflow-hidden border">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={cheer.image_url}
-            alt='掛け声画像'
-            className='w-full h-full object-contain absolute inset-0'
+            alt="掛け声画像"
+            className="w-full h-full object-contain absolute inset-0"
           />
         </div>
       )}
 
       {/* 掛け声テキストと説明 */}
-      <div className='text-card-foreground text-sm space-y-1'>
-        <div className='text-base font-bold'>{cheer.text}</div>
-        <div className='text-muted-foreground'>
+      <div className="text-card-foreground text-sm space-y-1">
+        <div className="text-base font-bold">{cheer.text}</div>
+        <div className="text-muted-foreground">
           {cheer.muscle?.name && <span>{cheer.muscle.name}</span>}
           {cheer.pose?.name && <span>・{cheer.pose.name}</span>}
         </div>
       </div>
 
       {/* アクションボタン */}
-      <div className='grid grid-cols-2 gap-2 sm:flex sm:justify-between sm:flex-wrap'>
+      <div className="grid grid-cols-2 gap-2 sm:flex sm:justify-between sm:flex-nowrap">
         <Link href={`/cheers/${cheer.id}/edit`}>
-          <Button variant='outline' size='sm' className='w-full min-w-[90px]'>
+          <Button
+            variant="outline"
+            size="sm"
+            className="min-w-[90px] w-full sm:w-auto"
+          >
             編集
           </Button>
         </Link>
 
         <Button
-          size='sm'
-          className='w-full min-w-[90px] bg-red-500 text-white hover:bg-red-600'
+          size="sm"
+          className="min-w-[90px] w-full sm:w-auto bg-red-500 text-white hover:bg-red-600"
           disabled={isPending || removing}
           onClick={handleDelete}
         >
@@ -69,26 +75,19 @@ export function CheerCard({ cheer, onDelete, showImage }: Props) {
         </Button>
 
         <Button
-          variant='outline'
-          size='sm'
-            className="w-full min-w-[90px] flex items-center justify-center gap-1 hover:bg-muted"
-          onClick={() =>
-            window.open(
-              `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                `「${cheer.text}」 #ムキメンタリー`
-              )}`,
-              "_blank"
-            )
-          }
+          variant="outline"
+          size="sm"
+          className="min-w-[90px] w-full sm:w-auto flex items-center justify-center gap-1 hover:bg-muted"
+          onClick={() => setShareOpenModal(true)}
         >
           <Share2 size={16} />
           シェア
         </Button>
 
         <Button
-          variant='secondary'
-          size='sm'
-          className='w-full min-w-[90px] flex items-center justify-center gap-1 border border-gray-300'
+          variant="secondary"
+          size="sm"
+          className="min-w-[90px] w-full sm:w-auto flex items-center justify-center gap-1 border border-gray-300"
           onClick={() => setOpenModal(true)}
         >
           <Plus size={16} />
@@ -101,6 +100,12 @@ export function CheerCard({ cheer, onDelete, showImage }: Props) {
         cheerId={cheer.id}
         open={openModal}
         onOpenChange={setOpenModal}
+      />
+
+      <ShareModal
+        cheerText={cheer.text}
+        open={shareOpenModal}
+        onOpenChange={setShareOpenModal}
       />
     </div>
   );

--- a/frontend/components/cheer/list/CheerDisplayController.tsx
+++ b/frontend/components/cheer/list/CheerDisplayController.tsx
@@ -39,6 +39,8 @@ export default function CheerDisplayController({
         >
           マイリスト一覧
         </Button>
+      {/* モーダル本体（選択で遷移） */}
+      <NavigateMyListModal open={modalOpen} onOpenChange={setModalOpen} />
 
         <Button
           size="sm"
@@ -49,9 +51,6 @@ export default function CheerDisplayController({
           {showImages ? "画像を非表示にする" : "画像をすべて表示"}
         </Button>
       </div>
-
-      {/* モーダル本体（選択で遷移） */}
-      <NavigateMyListModal open={modalOpen} onOpenChange={setModalOpen} />
 
       {/* 掛け声一覧 */}
       <CheersList

--- a/frontend/components/cheer/list/CheerTabs.tsx
+++ b/frontend/components/cheer/list/CheerTabs.tsx
@@ -6,13 +6,14 @@ import CheerManualForm from "../forms/CheerManualForm";
 import CheerAiForm from "../forms/CheerAiForm";
 import CheerImageAiForm from "../forms/CheerImageAiForm";
 import type { CheerType, Muscle, Pose } from "@/lib/types/prests";
-import type { CheerFormState } from "@/lib/types/cheer";
+import type { CheerFormState,Cheer } from "@/lib/types/cheer";
 import { useState } from "react";
 
 type Props = {
   cheerTypes: CheerType[];
   muscles: Muscle[];
   poses: Pose[];
+  cheerSamples: Cheer[]; 
   onSubmit: (form: CheerFormState) => void | Promise<void>;
 };
 
@@ -20,6 +21,7 @@ export default function CheerTabs({
   cheerTypes,
   muscles,
   poses,
+  cheerSamples,
   onSubmit,
 }: Props) {
   // グローバルで残り文字から掛け声生成回数のstateを持つ
@@ -64,6 +66,7 @@ export default function CheerTabs({
           muscles={muscles}
           poses={poses}
           onSubmit={onSubmit}
+          cheerSamples={cheerSamples}
           remaining={textAiRemaining}
           onChangeRemaining={setTextAiRemaining}
         />
@@ -74,6 +77,7 @@ export default function CheerTabs({
           muscles={muscles}
           poses={poses}
           onSubmit={onSubmit}
+          cheerSamples={cheerSamples}
           remaining={imageAiRemaining}
           onChangeRemaining={setImageAiRemaining}
         />

--- a/frontend/components/cheer/mylist/NavigateMyListModal.tsx
+++ b/frontend/components/cheer/mylist/NavigateMyListModal.tsx
@@ -4,7 +4,12 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useMyLists } from "@/lib/hooks/useMyLists";
 
@@ -33,23 +38,35 @@ export default function NavigateMyListModal({ open, onOpenChange }: Props) {
           <DialogTitle>マイリストを選択</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-2 mt-2">
+        <div className='space-y-2 mt-2'>
           {myLists.length > 0 ? (
             myLists.map((list) => (
               <Button
                 key={list.id}
-                variant="outline"
-                className="w-full justify-start"
+                variant='outline'
+                className='w-full justify-start'
                 onClick={() => handleSelect(list.id)}
               >
                 {list.name}
               </Button>
             ))
           ) : (
-            <p className="text-muted-foreground text-sm">
+            <p className='text-muted-foreground text-sm'>
               マイリストが見つかりません
             </p>
           )}
+        </div>
+        <div className='mt-4 text-center'>
+          <Button
+            variant='ghost'
+            className='text-sm text-muted-foreground underline hover:text-foreground'
+            onClick={() => {
+              onOpenChange(false);
+              router.push("/my-lists");
+            }}
+          >
+            マイリスト一覧ページへ
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/components/cheer/ui/GenerateCountInfo.tsx
+++ b/frontend/components/cheer/ui/GenerateCountInfo.tsx
@@ -1,15 +1,18 @@
 // frontend/components/cheer/ui/GenerateCountInfo.tsx
-//回数表示＆シェアボタンUIコンポーネント
+// 回数表示＆シェアボタンUIコンポーネント
 "use client";
 
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useCheerApi } from "@/lib/hooks/useCheerApi";
 import { toast } from "sonner";
+import { Cheer } from "@/lib/types/cheer";
+import { ShareForBonusModal } from "./ShareForBonusModal";
 
 type Props = {
   kind: "text_ai" | "image_ai";
-  onChangeRemaining?: (v: number) => void; // 親への回数残数通知
+  onChangeRemaining?: (v: number) => void;
+  cheerSamples: Cheer[];
 };
 
 type LimitResponse = {
@@ -17,49 +20,45 @@ type LimitResponse = {
   can_share: boolean;
 };
 
-export  function GenerateCountInfo({ kind, onChangeRemaining }: Props) {
-  //今ログインしているユーザーが、その日そのAI種別（テキスト or 画像）であと何回生成できるかの残り回数
+export function GenerateCountInfo({ kind, onChangeRemaining, cheerSamples }: Props) {
   const [remaining, setRemaining] = useState<number | null>(null);
-  //「シェアによる回数回復（+1回）」がまだ可能かどうか
   const [canShare, setCanShare] = useState(false);
-  //API通信中かどうか
-  const [loading, setLoading] = useState(false);
-  // APIフック
+  const [loading] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
   const { getAiLimit, postShareBonus } = useCheerApi();
 
+  // 生成可能回数取得
+  const fetchLimit = async () => {
+    try {
+      const data: LimitResponse = await getAiLimit(kind);
+      setRemaining(data.remaining);
+      setCanShare(data.can_share);
+      onChangeRemaining?.(data.remaining);
+    } catch {
+      toast.error("回数残数の取得に失敗しました");
+      onChangeRemaining?.(0);
+    }
+  };
 
-// 生成可能回数取得
-const fetchLimit = async () => {
-  try {
-    const data: LimitResponse = await getAiLimit(kind);
-    setRemaining(data.remaining);
-    setCanShare(data.can_share);
-    onChangeRemaining?.(data.remaining);
-  } catch {
-    toast.error("回数残数の取得に失敗しました");
-    onChangeRemaining?.(0); // エラー時は0に設定
-  }
-};
-
-  // 初回マウント時に残り回数を取得(ページ（またはタブ）が切り替わった時に、常に最新の残数・状態を表示するため)
   useEffect(() => {
     fetchLimit();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kind]);
 
-  // シェアボーナス付与
-  const handleShare = async () => {
-    setLoading(true);
-    try {
-      await postShareBonus(kind);
-      toast.success("AI生成回数が+1回されました!");
-      fetchLimit();
-    } catch {
+const handleBonusGranted = async () => {
+  try {
+    await postShareBonus(kind);
+    toast.success("AI生成回数が+1回されました!");
+    fetchLimit();
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("本日のシェアボーナスはすでに付与されています")) {
+      toast.info("今日はもうシェアボーナスを受け取っています");
+    } else {
       toast.error("シェアボーナス付与に失敗しました、しばらく経ってからお試しください");
-    } finally {
-      setLoading(false);
     }
-  };
+  }
+};
 
   return (
     <div className="flex flex-col gap-3 w-full text-sm px-2 text-foreground">
@@ -70,16 +69,24 @@ const fetchLimit = async () => {
       {canShare && (
         <div className="text-center">
           <Button
-            onClick={handleShare}
+            onClick={() => setModalOpen(true)}
             disabled={loading}
             size="sm"
             variant="ghost"
             className="text-sm text-primary hover:text-primary/80 underline"
           >
-            📣 {loading ? "付与中..." : "シェアして1日の利用回数を増やす"}
+            📣 シェアして1日の利用回数を増やす
           </Button>
         </div>
       )}
+
+      <ShareForBonusModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        cheers={cheerSamples}
+        kind={kind}
+        onSuccess={handleBonusGranted}
+      />
     </div>
   );
 }

--- a/frontend/components/cheer/ui/ShareForBonusModal.tsx
+++ b/frontend/components/cheer/ui/ShareForBonusModal.tsx
@@ -1,0 +1,70 @@
+//frontend/components/cheer/ui/ShareForBounusModal.tsx
+//ライブラリの中から掛け声を選んでTwitterに投稿するとシェアボーナス+1モーダル
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { useCheerApi } from "@/lib/hooks/useCheerApi";
+import type { Cheer } from "@/lib/types/cheer";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  cheers: Cheer[];
+  kind: "text_ai" | "image_ai";
+  onSuccess: () => void;
+}
+
+export function ShareForBonusModal({ open, onOpenChange, cheers, kind, onSuccess }: Props) {
+  const [loading, setLoading] = useState(false);
+  const { postShareBonus } = useCheerApi();
+
+  const handleShare = async (cheerText: string) => {
+    const shareText = `AIがあなたの筋トレを盛り上げる📣\n「${cheerText}」 \n素敵な掛け声を作ってシェアしよう💪 #ムキメンタリー https://mukimentary.com`;
+
+    // シェア先のURLを開く
+    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`, "_blank");
+
+    // シェアボーナス付与
+    setLoading(true);
+    try {
+      await postShareBonus(kind);
+      toast.success("AI生成回数が+1回されました!");
+      onSuccess();
+      onOpenChange(false);
+    } catch {
+      toast.error("シェアボーナス付与に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>シェアする掛け声を選んでください</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2 mt-2">
+          {cheers.length > 0 ? (
+            cheers.map((cheer) => (
+              <Button
+                key={cheer.id}
+                onClick={() => handleShare(cheer.text)}
+                disabled={loading}
+                variant="outline"
+                className="w-full justify-start"
+              >
+                {cheer.text}
+              </Button>
+            ))
+          ) : (
+            <p className="text-muted-foreground text-sm text-center">掛け声が見つかりません</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/cheer/ui/ShareModal.tsx
+++ b/frontend/components/cheer/ui/ShareModal.tsx
@@ -1,0 +1,53 @@
+//components/cheer/ui/ShareModal.tsx
+//作成した掛け声をクリップボードにコピーorXにシェア
+"use client";
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Copy } from "lucide-react";
+import { toast } from "sonner";
+
+type Props = {
+  cheerText: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function ShareModal({ cheerText, open, onOpenChange }: Props) {
+  const shareText = `AIがあなたの筋トレを盛り上げる📣
+「${cheerText}」 素敵な掛け声を作ってシェアしよう💪#ムキメンタリー https://mukimentary.com`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(cheerText);
+      toast.success("掛け声をコピーしました！");
+    } catch {
+      toast.error("コピーに失敗しました");
+    }
+  };
+
+  const handleShareToX = () => {
+    const encoded = encodeURIComponent(shareText);
+    window.open(`https://twitter.com/intent/tweet?text=${encoded}`, "_blank");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle>掛け声をシェア</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <Button onClick={handleShareToX} className="w-full">
+            Xにシェアする
+          </Button>
+          <Button variant="outline" onClick={handleCopy} className="w-full flex gap-2 justify-center items-center">
+            <Copy size={16} />
+            テキストをコピーする
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/lib/hooks/useCheerApi.ts
+++ b/frontend/lib/hooks/useCheerApi.ts
@@ -25,15 +25,32 @@ export function useCheerApi() {
 
   //POST /api/v1/cheers/share_bonus{ kind: "text_ai" or "image_ai" }
   //シェアボーナス（+1回）を付与API
-  const postShareBonus = async (kind: "text_ai" | "image_ai") => {
-    const res = await fetchWithAuth(`${API_BASE}/api/v1/cheers/share_bonus`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ kind }),
-    });
-    if (!res.ok) throw new Error("ボーナス付与に失敗しました");
-    return await res.json();
-  };
+const postShareBonus = async (kind: "text_ai" | "image_ai") => {
+  const res = await fetchWithAuth(`${API_BASE}/api/v1/cheers/share_bonus`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ kind }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    console.error("share_bonus error:", res.status, errorText);
+
+    if (res.status === 403) {
+      throw new Error("本日のシェアボーナスはすでに付与されています");
+    }
+
+    try {
+      const json = JSON.parse(errorText);
+      throw new Error(json.error || "シェアボーナス付与に失敗しました");
+    } catch {
+      throw new Error("シェアボーナス付与に失敗しました");
+    }
+  }
+
+  return await res.json();
+};
+
 
   // 掛け声AI生成（テキスト）
   const generateCheer = async (data: CheerGenerateRequest): Promise<CheerGenerateResponse> => {

--- a/frontend/lib/server/cheers.ts
+++ b/frontend/lib/server/cheers.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { PaginatedCheers, CheerFormState } from "@/lib/types/cheer";
 import { fetchWithAuthServer } from "@/lib/server/fetchWithAuthServer";
 import { getBaseUrl } from "@/lib/utils/getBaseUrl";
+import {Cheer} from "@/lib/types/cheer"
 
 // 全体またはフィルター付きの「自分の掛け声一覧」を取得（SSR/Server Action用）
 export async function getCheers({
@@ -104,3 +105,16 @@ export async function deleteCheer(id: number) {
 }
 
 
+// サンプル取得用：AI生成画面の掛け声ボーナスのために掛け声を最新順で取得
+// 掛け声のサンプルを取得（全体から数件だけ）
+export async function getCheerSamples(): Promise<Cheer[]> {
+  const API_BASE = getBaseUrl();
+  const res = await fetchWithAuthServer(`${API_BASE}/api/v1/cheers?page=1`);
+
+  if (!res.ok) {
+    throw new Error("掛け声サンプルの取得に失敗しました");
+  }
+
+  const data = await res.json();
+  return data.cheers.slice(0, 20); // 上位20件に制限（必要ならランダム化も可能）
+}


### PR DESCRIPTION
AI掛け声生成の残り回数表示コンポーネント（GenerateCountInfo）を作成

「シェアして回数+1」機能を導入し、利用可能な場合のみボタンを表示

モーダル（ShareForBonusModal）で掛け声を選択し、Xでシェアできる構成に

シェアテキストは AIがあなたの筋トレを盛り上げる📣... の定型文を使用

シェア後は postShareBonus を実行してサーバーに回数+1を通知

1日1回までのボーナス付与に対応し、403エラー時は「今日はもう受け取っています」と表示

cheers APIの仕様にあわせて掛け声サンプルの取得関数を調整

CheerTabs など親コンポーネントからサンプル掛け声をpropsで受け渡し

UIはスマホ対応・中央揃え・ボタンの見た目調整なども随時反映