### PR TITLE
rails落ち防止のpuma変更

### DIFF
--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -1,35 +1,16 @@
-# This configuration file will be evaluated by Puma. The top-level methods that
-# are invoked here are part of Puma's configuration DSL. For more information
-# about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
-
-# Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers: a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum; this matches the default thread size of Active Record.
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
-# Specifies that the worker count should equal the number of processors in production.
+# 💡 本番でもワーカー数を1に固定（Starterプランに最適）
 if ENV["RAILS_ENV"] == "production"
-  require "concurrent-ruby"
-  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
-  workers worker_count if worker_count > 1
+  workers 1
 end
 
-# Specifies the `worker_timeout` threshold that Puma will use to wait before
-# terminating a worker in development environments.
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT") { 3000 }
-
-# Specifies the `environment` that Puma will run in.
 environment ENV.fetch("RAILS_ENV") { "development" }
-
-# Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
-# Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
問題の概要（Render Starterプラン）
config/puma.rb で本番環境のワーカー数が自動的に CPUコア数（例：8）に設定されていた
Render Starterプラン（512MB）では、複数ワーカーはメモリ過剰で落ちる
その結果：Render側で「Web Service exceeded memory limit」エラー → 自動再起動

修正
スタータープランではワーカー 1、スレッド 5 が上限として最適
パフォーマンス不足を感じたら上位プラン（1GB以上）＋ワーカー数増加を検討

