### PR TITLE
画像AIがいいプロンプト返さない時のfallback処理

### DIFF
--- a/backend/app/services/cheer_generator_service.rb
+++ b/backend/app/services/cheer_generator_service.rb
@@ -5,13 +5,15 @@ require 'base64'
 class CheerGeneratorService
   # 文字ベース掛け声生成（このままでOK）
   def self.generate_from_text(cheer_type:, muscle:, pose:, keyword:)
-    prompt = PromptRenderer.render(
-      "cheer_from_text.txt.erb",
+    locals = {
       cheer_type: cheer_type,
       muscle: muscle,
       pose: pose,
       keyword: keyword
-    )
+    }
+
+    prompt = PromptRenderer.render("cheer_from_text.txt.erb", locals)
+
     client = OpenAI::Client.new
     response = client.chat(
       parameters: {
@@ -23,34 +25,39 @@ class CheerGeneratorService
         temperature: 0.7
       }
     )
+    #ネストされた JSON レスポンスの中から、実際の出力テキストだけを安全に取り出して、前後の空白を除いて返す処理
     response.dig("choices", 0, "message", "content").to_s.strip
   end
 
-  # 画像ベース掛け声生成（ここを修正）
-def self.generate_from_image(image_url:, cheer_type:, muscle:, pose:, keyword:)
-  prompt = PromptRenderer.render(
-    "cheer_from_image.txt.erb",
+  # 画像ベース掛け声生成
+  def self.generate_from_image(image_url:, cheer_type:, muscle:, pose:, keyword:)
+  # プロンプト用変数をまとめて定義
+  locals = {
     cheer_type: cheer_type,
     muscle: muscle,
     pose: pose,
     keyword: keyword
-  )
+  }
 
+  # 画像入力に基づくプロンプト生成
+  prompt = PromptRenderer.render("cheer_from_image.txt.erb", locals)
+
+  # 拡張子からMIMEタイプを判定（デフォルトは image/jpeg）
   ext = File.extname(URI.parse(image_url).path).delete('.').downcase
-  mime_type =
-    case ext
-    when "jpg", "jpeg" then "image/jpeg"
-    when "png"         then "image/png"
-    when "webp"        then "image/webp"
-    else "image/jpeg"
-    end
+  mime_type = case ext
+              when "jpg", "jpeg" then "image/jpeg"
+              when "png"         then "image/png"
+              when "webp"        then "image/webp"
+              else "image/jpeg"
+              end
 
-  # S3/LocalStackへのアクセス
+  # ローカル用URLに変換して画像データをBase64エンコード
   image_url_for_open = image_url.gsub("localhost:4566", "localstack:4566")
   image_data = URI.open(image_url_for_open).read
   base64_image = Base64.strict_encode64(image_data)
   data_url = "data:#{mime_type};base64,#{base64_image}"
 
+  # GPT-4o Vision モデルに画像とプロンプトを送信
   client = OpenAI::Client.new
   begin
     response = client.chat(
@@ -69,8 +76,19 @@ def self.generate_from_image(image_url:, cheer_type:, muscle:, pose:, keyword:)
         temperature: 0.7
       }
     )
+
     Rails.logger.debug(response.inspect)
-    response.dig("choices", 0, "message", "content").to_s.strip
+
+    cheer_text = response.dig("choices", 0, "message", "content").to_s.strip
+
+    # 出力が制限された場合（フィルター検知）→ テキストのみの生成にフォールバック
+    if cheer_text.include?("申し訳ありません") || cheer_text.include?("コンテンツに関する制限")
+      Rails.logger.warn("Vision出力が制限されたため、テキストベース生成にfallbackします")
+      return self.generate_from_text(**locals)
+    end
+
+    return cheer_text
+
   rescue => e
     if e.respond_to?(:response) && e.response && e.response[:body]
       Rails.logger.error("OpenAIエラー詳細: #{e.response[:body]}")
@@ -78,6 +96,4 @@ def self.generate_from_image(image_url:, cheer_type:, muscle:, pose:, keyword:)
     Rails.logger.error("AI生成エラー詳細: #{e.message}\n#{e.backtrace.join("\n")}")
     raise
   end
-end
-
 end

--- a/backend/app/services/prompt_renderer.rb
+++ b/backend/app/services/prompt_renderer.rb
@@ -1,7 +1,19 @@
 # backend/app/services/prompt_renderer.rb
+#テンプレートファイルに、変数（cheer_type など）を埋め込んで、1つの文字列（プロンプト）にして返すためのクラス
 class PromptRenderer
   def self.render(template_name, locals)
+    # config/prompts/ 配下のテンプレートファイルのパスを生成する
+    # 例: "cheer_from_text.txt.erb" → Rails.root/config/prompts/cheer_from_text.txt.erb
     path = Rails.root.join("config", "prompts", template_name)
+
+    # ファイルを読み込み、ERBテンプレートとしてインスタンス化し、localsハッシュ内の変数を埋め込んで最終的な文字列を生成する
     ERB.new(File.read(path)).result_with_hash(locals)
   end
 end
+
+
+
+
+
+
+


### PR DESCRIPTION
generate_from_text と generate_from_image を明確に分離し、役割ごとに処理を整理

両メソッドで共通する引数を locals ハッシュにまとめ、テンプレート描画を簡潔化

Visionモデル使用時の画像データを Base64 エンコードし、data_url として送信

MIMEタイプをファイル拡張子から自動判定し、汎用性を向上

OpenAI APIのレスポンスから掛け声文のみを安全に抽出（dig + to_s.strip）

「センシティブな内容」などフィルター制限に引っかかった場合は自動でテキスト生成にフォールバック

すべての処理にログ出力とエラーハンドリングを追加し、運用上のトラブル対応を強化

